### PR TITLE
go.mod, ci: pin to v1.17; go mod tidy

### DIFF
--- a/.github/workflows/push-pr-lint.yaml
+++ b/.github/workflows/push-pr-lint.yaml
@@ -8,7 +8,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.16.0'
+        go-version: '^1.17.0'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,31 @@
 module github.com/packethost/ironlib
 
-go 1.16
+go 1.17
 
 require (
 	github.com/beevik/etree v1.1.0
 	github.com/dselans/dmidecode v0.0.0-20180814053009-65c3f9d81910
-	github.com/google/go-cmp v0.5.5 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/r3labs/diff/v2 v2.13.6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.6.1
 	github.com/tidwall/gjson v1.14.1
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gotest.tools v2.2.0+incompatible
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
# What does this PR do

Pins to Go version `1.17` from `1.16`
