### PR TITLE
docker: purge packages included for debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,17 +113,8 @@ COPY --from=stage0 dell_pgp_keys/* /usr/libexec/dell_dup/
 
 # install misc support packages
 RUN  microdnf install -y --setopt=tsflags=nodocs \
-                   vim           \
-                   tar           \
                    lshw          \
-                   unzip         \
-                   nano          \
-                   gzip          \
-                   less          \
-                   which         \
-                   strace        \
                    pciutils      \
-                   passwd        \
                    nvme-cli      \
                    dmidecode     \
                    libssh2-devel \


### PR DESCRIPTION
# What does this PR do

This removes packages included for debugging purposes, drops the size further down to 274MB from 308MB