### PR TITLE
utils/smc_sum: add conditional update command flag for X12STH-SYS

### DIFF
--- a/utils/smc_sum_test.go
+++ b/utils/smc_sum_test.go
@@ -9,6 +9,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_SMCUpdateBios(t *testing.T) {
+	testCases := []struct {
+		testName    string
+		model       string
+		expectedCmd string
+	}{
+		{
+			"model specific update command",
+			"X12STH-SYS",
+			"-c UpdateBios --file /tmp/foo",
+		},
+		{
+			"generic update command",
+			"generic",
+			"-c UpdateBios --preserve_setting --file /tmp/foo",
+		},
+	}
+
+	sum := NewFakeSMCSum(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			err := sum.UpdateBIOS(context.TODO(), "/tmp/foo", tc.model)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			assert.Equal(t, tc.expectedCmd, sum.Executor.GetCmd())
+		})
+	}
+}
+
 func Test_parseSMCBIOSConfig_X11SCHFF(t *testing.T) {
 	expected := map[string]string{"boot_mode": "BIOS",
 		"intel_sgx":                                 "Software Controlled",


### PR DESCRIPTION
#### What does this PR do

This SMC hardware variant does not support the `--preserve_setting` option when installing BIOS updates,
and so an exception for this model is added.

```
/sum_2.7.0_Linux_x86_64# ./sum -c UpdateBios --preserve_setting --file
../BIOS_X12STH-1C3A_20211213_1.0a_STDsp/BIOS_X12STH-1C3A_20211213_1.0a_STDsp.bin
Supermicro Update Manager (for UEFI BIOS) 2.7.0 (2021/09/03) (x86_64)
Copyright(C) 2013-2021 Super Micro Computer, Inc. All rights reserved.

********************************<<<<<ERROR>>>>>*********************************

ExitCode                = 38
Description             = Function is not supported
Program Error Code      = 198.34
Error message:
        --preserve_setting does not support on this platform for in-band
        usage.
```

#### The HW vendor this change applies to (if applicable)

Supermicro

#### The HW model number, product name this change applies to (if applicable)

X12STH-SYS

#### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

#### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

`sum_2.7.0_Linux_x86_64`

#### How can this change be tested by a PR reviewer?

#### Description for changelog/release notes

- Support updates for X12STH-SYS