### PR TITLE
Add kmod to avoid error running lsmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN microdnf install -y --setopt=tsflags=nodocs \
                               curl         \
                               tar          \
                               gzip         \
-                              unzip
+                              unzip        \
+                              kmod
 
 # epel repo package
 RUN curl -sO https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm


### PR DESCRIPTION
# What does this PR do

Add `kmod` package so `lsmod` tool will be available during inventory collection

# The HW vendor this change applies to (if applicable)

All

# The HW model number, product name this change applies to (if applicable)

# The BMC firmware and/or BIOS versions that this change applies to (if applicable)

# What version of tooling - vendor specific or opensource does this change depend on (if applicable)

n/a

# How can this change be tested by a PR reviewer?


# Description for changelog/release notes

Add kmod to avoid error running lsmod during inventory collection