### PR TITLE
Multiple drive collectors

### DIFF
--- a/actions/inventory_test.go
+++ b/actions/inventory_test.go
@@ -30,7 +30,7 @@ func Test_Inventory_dell(t *testing.T) {
 	smartctl := utils.NewFakeSmartctl("../fixtures/dell/r6515/smartctl")
 	collectors := &Collectors{
 		Inventory: lshw,
-		Drives:    smartctl,
+		Drives:    []DriveCollector{smartctl},
 	}
 
 	err = Collect(context.TODO(), &device, collectors, true, false)
@@ -101,7 +101,7 @@ func Test_Inventory_smc(t *testing.T) {
 
 	collectors := &Collectors{
 		Inventory:          lshw,
-		Drives:             smartctl,
+		Drives:             []DriveCollector{smartctl},
 		NICs:               mlxup,
 		CPLDs:              ipmicfg0,
 		BIOS:               ipmicfg1,

--- a/providers/dell/dell_test.go
+++ b/providers/dell/dell_test.go
@@ -41,7 +41,7 @@ func newFakeDellDevice() (*dell, error) {
 
 	collectors := &actions.Collectors{
 		Inventory: lshw,
-		Drives:    smartctl,
+		Drives:    []actions.DriveCollector{smartctl},
 	}
 
 	hardware := model.NewHardware(&device)

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -31,7 +31,7 @@ func New(dmidecode *utils.Dmidecode, l *logrus.Logger) (model.DeviceManager, err
 		BMC:                utils.NewIpmicfgCmd(trace),
 		BIOS:               utils.NewIpmicfgCmd(trace),
 		CPLDs:              utils.NewIpmicfgCmd(trace),
-		Drives:             utils.NewSmartctlCmd(trace),
+		Drives:             []actions.DriveCollector{utils.NewSmartctlCmd(trace)},
 		StorageControllers: utils.NewStoreCLICmd(trace),
 		NICs:               utils.NewMlxupCmd(trace),
 	}


### PR DESCRIPTION
### What does this PR do

Update actions inventory collection to support registering and executing multiple drive collectors.