### PR TITLE
actions/storage_controller.go: DestroyVirtualDisk() 2nd param s/Device/StorageController/

### DIFF
--- a/actions/storage_controller.go
+++ b/actions/storage_controller.go
@@ -24,7 +24,7 @@ func CreateVirtualDisk(ctx context.Context, hba *common.StorageController, optio
 	return util.CreateVirtualDisk(ctx, options.RaidMode, options.PhysicalDiskIDs, options.Name, options.BlockSize)
 }
 
-func DestroyVirtualDisk(ctx context.Context, hba *common.Device, options *model.DestroyVirtualDiskOptions) error {
+func DestroyVirtualDisk(ctx context.Context, hba *common.StorageController, options *model.DestroyVirtualDiskOptions) error {
 	util, err := GetControllerUtility(hba.Vendor, hba.Model)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do
actions.DestroyVirtualDisk() should take a *common.StorageController rather than a *common.Device

### How can this change be tested by a PR reviewer?

actions.DestroyVirtualDisk() can be called with a *common.StorageController as the 2nd parameter (and it actually destroys the virtual disk..)

### Description for changelog/release notes
Fixes actions.DestroyVirtualDisk method signature.