### PR TITLE
Add StorageControllerDriveID to utils.mvcli Drives() return

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/beevik/etree v1.1.0
-	github.com/bmc-toolbox/common v0.0.0-20221027142600-dd231ee11e95
+	github.com/bmc-toolbox/common v0.0.0-20221104171658-00f3ff9e9233
 	github.com/dselans/dmidecode v0.0.0-20180814053009-65c3f9d81910
 	github.com/pkg/errors v0.9.1
 	github.com/r3labs/diff/v2 v2.15.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
-github.com/bmc-toolbox/common v0.0.0-20221027142600-dd231ee11e95 h1:ZKq2USYtq9S0uujNIsJzkufk4C/n4vPhKzH2nO02hwE=
-github.com/bmc-toolbox/common v0.0.0-20221027142600-dd231ee11e95/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
+github.com/bmc-toolbox/common v0.0.0-20221104171658-00f3ff9e9233 h1:kGmMpnHvp3KebZbEMHZHR4pVMqk/otXzvwcFhMg++7M=
+github.com/bmc-toolbox/common v0.0.0-20221104171658-00f3ff9e9233/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/utils/mvcli.go
+++ b/utils/mvcli.go
@@ -189,10 +189,11 @@ func (m *Mvcli) Drives(ctx context.Context) ([]*common.Drive, error) {
 				Metadata:    make(map[string]string),
 			},
 
-			BlockSizeBytes:      d.Size,
-			CapacityBytes:       d.PDSize,
-			Type:                m.processDriveType(d.Type, d.SSDType),
-			NegotiatedSpeedGbps: d.CurrentSpeed,
+			BlockSizeBytes:           d.Size,
+			CapacityBytes:            d.PDSize,
+			Type:                     m.processDriveType(d.Type, d.SSDType),
+			NegotiatedSpeedGbps:      d.CurrentSpeed,
+			StorageControllerDriveID: d.ID,
 		}
 
 		drives = append(drives, drive)

--- a/utils/mvcli_test.go
+++ b/utils/mvcli_test.go
@@ -75,10 +75,11 @@ func Test_MvcliDrives(t *testing.T) {
 					Metadata:  nil,
 				},
 			},
-			CapacityBytes:       234365528 * 1000,
-			BlockSizeBytes:      234431064 * 1000,
-			Type:                common.SlugDriveTypeSATASSD,
-			NegotiatedSpeedGbps: 6,
+			CapacityBytes:            234365528 * 1000,
+			BlockSizeBytes:           234431064 * 1000,
+			Type:                     common.SlugDriveTypeSATASSD,
+			NegotiatedSpeedGbps:      6,
+			StorageControllerDriveID: 0,
 		},
 		{
 			Common: common.Common{
@@ -93,10 +94,11 @@ func Test_MvcliDrives(t *testing.T) {
 					Metadata:  nil,
 				},
 			},
-			CapacityBytes:       234365528 * 1000,
-			BlockSizeBytes:      234431064 * 1000,
-			Type:                common.SlugDriveTypeSATASSD,
-			NegotiatedSpeedGbps: 6,
+			CapacityBytes:            234365528 * 1000,
+			BlockSizeBytes:           234431064 * 1000,
+			Type:                     common.SlugDriveTypeSATASSD,
+			NegotiatedSpeedGbps:      6,
+			StorageControllerDriveID: 1,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do

Adds StorageControllerDriveID to utils.mvcli Drives() return

### The HW vendor this change applies to (if applicable)

* Marvell storage controllers, in particular.

### Description for changelog/release notes

Adds StorageControllerDriveID to utils.mvcli Drives() return