### PR TITLE
Options and multiple storagecontrollers

### DIFF
--- a/actions/inventory_test.go
+++ b/actions/inventory_test.go
@@ -113,14 +113,14 @@ func Test_Inventory_smc(t *testing.T) {
 	}
 
 	collectors := &Collectors{
-		InventoryCollector:         lshw,
-		DriveCollectors:            []DriveCollector{smartctl},
-		NICCollector:               mlxup,
-		CPLDCollector:              ipmicfg0,
-		BIOSCollector:              ipmicfg1,
-		BMCCollector:               ipmicfg2,
-		TPMCollector:               dmi,
-		StorageControllerCollector: storecli,
+		InventoryCollector:          lshw,
+		DriveCollectors:             []DriveCollector{smartctl},
+		NICCollector:                mlxup,
+		CPLDCollector:               ipmicfg0,
+		BIOSCollector:               ipmicfg1,
+		BMCCollector:                ipmicfg2,
+		TPMCollector:                dmi,
+		StorageControllerCollectors: []StorageControllerCollector{storecli},
 	}
 
 	collector := NewInventoryCollectorAction(WithCollectors(collectors), WithTraceLevel())

--- a/actions/inventory_test.go
+++ b/actions/inventory_test.go
@@ -130,3 +130,84 @@ func Test_Inventory_smc(t *testing.T) {
 
 	assert.Equal(t, smcFixtures.Testdata_X11DPH_T_Inventory, &device)
 }
+
+// nolint:gocyclo // Test code isn't pretty
+func TestNewInventoryCollectorAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []Option
+		want    *InventoryCollectorAction
+	}{
+		{
+			"trace-enabled",
+			[]Option{WithTraceLevel()},
+			&InventoryCollectorAction{trace: true},
+		},
+		{
+			"trace-disabled",
+			[]Option{},
+			&InventoryCollectorAction{},
+		},
+		{
+			"dynamic-collectors",
+			[]Option{WithDynamicCollection()},
+			&InventoryCollectorAction{dynamicCollection: true},
+		},
+		{
+			"fail-on-error",
+			[]Option{WithFailOnError()},
+			&InventoryCollectorAction{failOnError: true},
+		},
+		{
+			"collectors-empty",
+			[]Option{},
+			&InventoryCollectorAction{},
+		},
+		{
+			"default-collectors-set",
+			[]Option{},
+			&InventoryCollectorAction{},
+		},
+		{
+			"default-lshw-collector",
+			[]Option{},
+			&InventoryCollectorAction{},
+		},
+		{
+			"default-drive-collectors",
+			[]Option{},
+			&InventoryCollectorAction{},
+		},
+		{
+			"default-drive-capabilities-collector",
+			[]Option{},
+			&InventoryCollectorAction{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewInventoryCollectorAction(tt.options...)
+
+			switch tt.name {
+			case "trace-enabled":
+				assert.Equal(t, true, got.trace)
+			case "trace-disabled":
+				assert.Equal(t, false, got.trace)
+			case "dynamic-collectors":
+				assert.Equal(t, true, got.dynamicCollection)
+			case "fail-on-error":
+				assert.Equal(t, true, got.failOnError)
+			case "collectors-empty":
+				assert.Equal(t, true, tt.want.collectors.Empty())
+			case "default-collectors-set":
+				assert.Equal(t, false, got.collectors.Empty())
+			case "default-lshw-collector":
+				assert.Equal(t, false, got.collectors.InventoryCollector == nil)
+			case "default-drive-collector":
+				assert.Equal(t, false, len(got.collectors.DriveCollectors) == 0)
+			case "default-drive-capabilities-collector":
+				assert.Equal(t, false, len(got.collectors.DriveCapabilitiesCollectors) == 0)
+			}
+		})
+	}
+}

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -89,8 +89,10 @@ func (s *supermicro) GetInventory(ctx context.Context, options ...actions.Option
 			utils.NewHdparmCmd(trace),
 			utils.NewNvmeCmd(trace),
 		},
-		StorageControllerCollector: utils.NewStoreCLICmd(trace),
-		NICCollector:               utils.NewMlxupCmd(trace),
+		StorageControllerCollectors: []actions.StorageControllerCollector{
+			utils.NewStoreCLICmd(trace),
+		},
+		NICCollector: utils.NewMlxupCmd(trace),
 	}
 
 	options = append(options, actions.WithCollectors(collectors))


### PR DESCRIPTION
### What does this PR do

- Fixes trace level logging option not being set on collector utilities
- Implements support for multiple storage controller collectors


### Description for changelog/release notes
- Support multiple storage controller collectors