### PR TITLE
StorageController and Drives collector fixes

### DIFF
--- a/.github/workflows/push-pr-lint.yaml
+++ b/.github/workflows/push-pr-lint.yaml
@@ -15,6 +15,6 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         args: --config .golangci.yml
-        version: v1.50.0
+        version: v1.51.2
     - name: Test
       run: go test ./...

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -796,7 +796,7 @@ func (a *InventoryCollectorAction) vetUpdate(change *diff.Change) bool {
 			return true
 		}
 	case int:
-		if newValue != int(0) {
+		if newValue >= -1 {
 			return true
 		}
 	case int64:

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -250,7 +250,9 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 		for _, sc := range a.device.StorageControllers {
 			c := DriveCollectorByStorageControllerVendor(sc.Vendor, a.trace)
 
-			if c != nil {
+			if c := DriveCollectorByStorageControllerVendor(sc.Vendor, a.trace); c != nil {
+                a.collectors.DriveCollectors = append(a.collectors.DriveCollectors, c)
+            }
 				a.collectors.DriveCollectors = append(a.collectors.DriveCollectors, c)
 			}
 		}

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -251,7 +251,9 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 			if c != nil {
 				a.collectors.DriveCollectors = append(a.collectors.DriveCollectors, c)
 			}
+		}
 
+		if len(a.collectors.DriveCollectors) > 0 {
 			err = a.CollectDrives(ctx)
 
 			if err != nil && a.failOnError {

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -229,7 +229,9 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 	// Update StorageControllerCollectors based on controller vendor attributes
 	if a.dynamicCollection {
 		for _, sc := range a.device.StorageControllers {
-			c := StorageControllerCollectorByVendor(sc.Vendor, a.trace)
+		if c := StorageControllerCollectorByVendor(sc.Vendor, a.trace); c != nil {
+            a.collectors.StorageControllerCollectors = append(a.collectors.StorageControllerCollectors, c)
+        }
 
 			if c != nil {
 				a.collectors.StorageControllerCollectors = append(a.collectors.StorageControllerCollectors, c)

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -229,11 +229,7 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 	// Update StorageControllerCollectors based on controller vendor attributes
 	if a.dynamicCollection {
 		for _, sc := range a.device.StorageControllers {
-		if c := StorageControllerCollectorByVendor(sc.Vendor, a.trace); c != nil {
-            a.collectors.StorageControllerCollectors = append(a.collectors.StorageControllerCollectors, c)
-        }
-
-			if c != nil {
+			if c := StorageControllerCollectorByVendor(sc.Vendor, a.trace); c != nil {
 				a.collectors.StorageControllerCollectors = append(a.collectors.StorageControllerCollectors, c)
 			}
 		}
@@ -248,11 +244,7 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 	// Update DriveCollectors based on drive vendor attributes
 	if a.dynamicCollection {
 		for _, sc := range a.device.StorageControllers {
-			c := DriveCollectorByStorageControllerVendor(sc.Vendor, a.trace)
-
 			if c := DriveCollectorByStorageControllerVendor(sc.Vendor, a.trace); c != nil {
-                a.collectors.DriveCollectors = append(a.collectors.DriveCollectors, c)
-            }
 				a.collectors.DriveCollectors = append(a.collectors.DriveCollectors, c)
 			}
 		}

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -229,10 +229,11 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 	// Update StorageControllerCollectors based on controller vendor attributes
 	if a.dynamicCollection {
 		for _, sc := range a.device.StorageControllers {
-			a.collectors.StorageControllerCollectors = append(
-				a.collectors.StorageControllerCollectors,
-				StorageControllerCollectorByVendor(sc.Vendor, a.trace),
-			)
+			c := StorageControllerCollectorByVendor(sc.Vendor, a.trace)
+
+			if c != nil {
+				a.collectors.StorageControllerCollectors = append(a.collectors.StorageControllerCollectors, c)
+			}
 		}
 	}
 
@@ -245,14 +246,11 @@ func (a *InventoryCollectorAction) Collect(ctx context.Context, device *common.D
 	// Update DriveCollectors based on drive vendor attributes
 	if a.dynamicCollection {
 		for _, sc := range a.device.StorageControllers {
-			if sc.SupportedRAIDTypes == "" {
-				continue
-			}
+			c := DriveCollectorByStorageControllerVendor(sc.Vendor, a.trace)
 
-			a.collectors.DriveCollectors = append(
-				a.collectors.DriveCollectors,
-				DriveCollectorByStorageControllerVendor(sc.Vendor, a.trace),
-			)
+			if c != nil {
+				a.collectors.DriveCollectors = append(a.collectors.DriveCollectors, c)
+			}
 
 			err = a.CollectDrives(ctx)
 

--- a/fixtures/asrr/e3c246d4i-nl.go
+++ b/fixtures/asrr/e3c246d4i-nl.go
@@ -1000,7 +1000,7 @@ var E3C246D4INL = &common.Device{
 			Common: common.Common{
 				Oem:          false,
 				Description:  "SATA controller",
-				Vendor:       "Intel Corporation",
+				Vendor:       "intel",
 				Model:        "Cannon Lake PCH SATA AHCI Controller",
 				Serial:       "000f:d00f",
 				ProductName:  "Cannon Lake PCH SATA AHCI Controller",

--- a/fixtures/dell/r6515.go
+++ b/fixtures/dell/r6515.go
@@ -1617,7 +1617,7 @@ var (
 				Common: common.Common{
 					Oem:          false,
 					Description:  "Serial Attached SCSI controller",
-					Vendor:       "Broadcom / LSI",
+					Vendor:       "broadcom",
 					Model:        "SAS3008 PCI-Express Fusion-MPT SAS-3",
 					Serial:       "dead:beef",
 					ProductName:  "SAS3008 PCI-Express Fusion-MPT SAS-3",
@@ -1680,7 +1680,7 @@ var (
 				Common: common.Common{
 					Oem:          false,
 					Description:  "SATA controller",
-					Vendor:       "Marvell Technology Group Ltd.",
+					Vendor:       "marvell",
 					Model:        "88SE9230 PCIe SATA 6Gb/s Controller",
 					Serial:       common.VendorMarvellPciID + ":beef",
 					ProductName:  "88SE9230 PCIe SATA 6Gb/s Controller",
@@ -3201,7 +3201,7 @@ var (
 				Common: common.Common{
 					Oem:          false,
 					Description:  "Serial Attached SCSI controller",
-					Vendor:       "Broadcom / LSI",
+					Vendor:       "broadcom",
 					Model:        "SAS3008 PCI-Express Fusion-MPT SAS-3",
 					Serial:       "dead:beef",
 					ProductName:  "SAS3008 PCI-Express Fusion-MPT SAS-3",
@@ -3264,7 +3264,7 @@ var (
 				Common: common.Common{
 					Oem:          false,
 					Description:  "SATA controller",
-					Vendor:       "Marvell Technology Group Ltd.",
+					Vendor:       "marvell",
 					Model:        "88SE9230 PCIe SATA 6Gb/s Controller",
 					Serial:       common.VendorMarvellPciID + ":beef",
 					ProductName:  "88SE9230 PCIe SATA 6Gb/s Controller",

--- a/fixtures/supermicro/x11dph-t.go
+++ b/fixtures/supermicro/x11dph-t.go
@@ -2880,7 +2880,7 @@ var (
 				Common: common.Common{
 					Oem:          false,
 					Description:  "Serial Attached SCSI controller",
-					Vendor:       "Broadcom / LSI",
+					Vendor:       "broadcom",
 					Model:        "SAS3008 PCI-Express Fusion-MPT SAS-3",
 					Serial:       "dead:beef",
 					ProductName:  "SAS3008 PCI-Express Fusion-MPT SAS-3",

--- a/utils/lshw.go
+++ b/utils/lshw.go
@@ -559,7 +559,7 @@ func (l *Lshw) xStorageController(node *LshwNode) *common.StorageController {
 	sc := &common.StorageController{
 		Common: common.Common{
 			Description: node.Description,
-			Vendor:      node.Vendor,
+			Vendor:      common.FormatVendorName(node.Vendor),
 			Model:       node.Product,
 			Serial:      node.Serial,
 			ProductName: node.Product,

--- a/utils/smartctl.go
+++ b/utils/smartctl.go
@@ -114,8 +114,9 @@ func (s *Smartctl) Drives(ctx context.Context) ([]*common.Drive, error) {
 				},
 			},
 
-			Type:        model.DriveTypeSlug(smartctlAll.ModelName),
-			SmartStatus: common.SmartStatusUnknown,
+			Type:                     model.DriveTypeSlug(smartctlAll.ModelName),
+			SmartStatus:              common.SmartStatusUnknown,
+			StorageControllerDriveID: -1,
 		}
 
 		if item.Vendor == "" {

--- a/utils/smartctl_test.go
+++ b/utils/smartctl_test.go
@@ -61,11 +61,11 @@ func Test_SmartctlAllNVME(t *testing.T) {
 
 func Test_SmartctlDeviceAttributes(t *testing.T) {
 	expected := []*common.Drive{
-		{Common: common.Common{Serial: "2013273A99BD", Vendor: common.VendorMicron, Model: "Micron_5200_MTFDDAK960TDN", ProductName: "Micron_5200_MTFDDAK960TDN", Firmware: &common.Firmware{Installed: "D1MU020"}}, Type: common.SlugDriveTypeSATASSD, SmartStatus: "ok"},
-		{Common: common.Common{Serial: "VDJ6SU9K", Vendor: common.VendorHGST, Model: "HGST HUS728T8TALE6L4", ProductName: "HGST HUS728T8TALE6L4", Firmware: &common.Firmware{Installed: "V8GNW460"}}, Type: common.SlugDriveTypeSATAHDD, SmartStatus: "ok"},
-		{Common: common.Common{Serial: "PHYH1016001D240J", Vendor: common.VendorDell, Model: "SSDSCKKB240G8R", ProductName: "SSDSCKKB240G8R", Firmware: &common.Firmware{Installed: "XC31DL6R"}}, Type: "Unknown", SmartStatus: "ok", OemID: "DELL(tm)"},
-		{Common: common.Common{Serial: "Z9DF70I8FY3L", Vendor: common.VendorToshiba, Model: "KXG60ZNV256G TOSHIBA", ProductName: "KXG60ZNV256G TOSHIBA", Firmware: &common.Firmware{Installed: "AGGA4104"}}, Type: common.SlugDriveTypePCIeNVMEeSSD, SmartStatus: "ok"},
-		{Common: common.Common{Serial: "Z9DF70I9FY3L", Vendor: common.VendorToshiba, Model: "KXG60ZNV256G TOSHIBA", ProductName: "KXG60ZNV256G TOSHIBA", Firmware: &common.Firmware{Installed: "AGGA4104"}}, Type: common.SlugDriveTypePCIeNVMEeSSD, SmartStatus: "ok"},
+		{Common: common.Common{Serial: "2013273A99BD", Vendor: common.VendorMicron, Model: "Micron_5200_MTFDDAK960TDN", ProductName: "Micron_5200_MTFDDAK960TDN", Firmware: &common.Firmware{Installed: "D1MU020"}}, Type: common.SlugDriveTypeSATASSD, SmartStatus: "ok", StorageControllerDriveID: -1},
+		{Common: common.Common{Serial: "VDJ6SU9K", Vendor: common.VendorHGST, Model: "HGST HUS728T8TALE6L4", ProductName: "HGST HUS728T8TALE6L4", Firmware: &common.Firmware{Installed: "V8GNW460"}}, Type: common.SlugDriveTypeSATAHDD, SmartStatus: "ok", StorageControllerDriveID: -1},
+		{Common: common.Common{Serial: "PHYH1016001D240J", Vendor: common.VendorDell, Model: "SSDSCKKB240G8R", ProductName: "SSDSCKKB240G8R", Firmware: &common.Firmware{Installed: "XC31DL6R"}}, Type: "Unknown", SmartStatus: "ok", OemID: "DELL(tm)", StorageControllerDriveID: -1},
+		{Common: common.Common{Serial: "Z9DF70I8FY3L", Vendor: common.VendorToshiba, Model: "KXG60ZNV256G TOSHIBA", ProductName: "KXG60ZNV256G TOSHIBA", Firmware: &common.Firmware{Installed: "AGGA4104"}}, Type: common.SlugDriveTypePCIeNVMEeSSD, SmartStatus: "ok", StorageControllerDriveID: -1},
+		{Common: common.Common{Serial: "Z9DF70I9FY3L", Vendor: common.VendorToshiba, Model: "KXG60ZNV256G TOSHIBA", ProductName: "KXG60ZNV256G TOSHIBA", Firmware: &common.Firmware{Installed: "AGGA4104"}}, Type: common.SlugDriveTypePCIeNVMEeSSD, SmartStatus: "ok", StorageControllerDriveID: -1},
 	}
 	s := newFakeSmartctl()
 


### PR DESCRIPTION
### What does this PR do

Corrects the handling of "dynamic" StorageController and Drive collectors. 

### The HW vendor this change applies to (if applicable)

All StorageController and Drive dynamic collectors which at this point is just Marvell (mvcli).