### PR TITLE
utils/lsblk.go: No longer assume 'PATH' is a valid lsblk column name

### DIFF
--- a/fixtures/utils/lsblk/json
+++ b/fixtures/utils/lsblk/json
@@ -2,7 +2,7 @@
     "blockdevices": [
         {
             "name": "sda",
-            "path": "/dev/sda",
+            "kname": "/dev/sda",
             "model": "MTFDDAV240TDU",
             "serial": "203329F89392",
             "rev": "2B6Q",
@@ -10,7 +10,7 @@
         },
         {
             "name": "sdb",
-            "path": "/dev/sdb",
+            "kname": "/dev/sdb",
             "model": "MTFDDAV240TDU     ",
             "serial": "203329F89796",
             "rev": "2B6Q",
@@ -18,7 +18,7 @@
         },
         {
             "name": "nvme0",
-            "path": "/dev/nvme0",
+            "kname": "/dev/nvme0",
             "model": "Micron_9300_MTFDHAL3T8TDP         ",
             "serial": "202728F691F5         ",
             "rev": null,
@@ -26,7 +26,7 @@
         },
         {
             "name": "nvme0",
-            "path": "/dev/nvme1       ",
+            "kname": "/dev/nvme1       ",
             "model": "Micron_9300_MTFDHAL3T8TDP         ",
             "serial": "202728F691C6",
             "rev": null,

--- a/utils/lsblk.go
+++ b/utils/lsblk.go
@@ -22,8 +22,8 @@ type Lsblk struct {
 }
 
 type lsblkDeviceAttributes struct {
-	Name      string `json:"kname"`
-	Device    string `json:"path"`
+	Name      string `json:"name"`
+	Device    string `json:"kname"`
 	Model     string `json:"model"`
 	Serial    string `json:"serial"`
 	Firmware  string `json:"rev:"`
@@ -103,7 +103,7 @@ func (l *Lsblk) Drives(ctx context.Context) ([]*common.Drive, error) {
 
 func (l *Lsblk) list(ctx context.Context) ([]byte, error) {
 	// lsblk --json --nodeps --output name,path,model,serial,tran -e1,7,11
-	l.Executor.SetArgs([]string{"--json", "--nodeps", "--output", "kname,path,model,serial,rev,tran", "-e1,7,11"})
+	l.Executor.SetArgs([]string{"--json", "--nodeps", "-p", "--output", "kname,name,model,serial,rev,tran", "-e1,7,11"})
 
 	result, err := l.Executor.ExecWithContext(ctx)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do

Different versions of lsblk do or do not support 'PATH' as an output column.    The '-p' option allows for full paths in all columns containing something 'pathable' so we can rely on that instead.  