### PR TITLE
Support building container image for arm64

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -53,6 +53,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Sign the images with GitHub OIDC Token
         run: cosign sign --yes ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}


### PR DESCRIPTION
### What does this PR do

Allows an arm64 based ironlib image to be built.     

### Limitations

* Currently there are no dell utilities for arm64 (and afaik there are no arm machines from dell, so :shrug: )
