### PR TITLE
.github/workflows/release-docker-image.yml: Use --recursive when calling cosign sign

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -56,7 +56,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Sign the images with GitHub OIDC Token
-        run: cosign sign --yes ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}
+        run: cosign sign --recursive --yes ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: true
 


### PR DESCRIPTION
…ing cosign sign

### What does this PR do

Currently we sign our multiarch docker image without the --recursive option.   It's believed this 'breaks' our multiarch image.