### PR TITLE
Repush images after signing is complete

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -46,7 +47,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push image
+      - name: Build and Push Images
         id: dockerbuild
         uses: docker/build-push-action@v4
         with:
@@ -55,19 +56,28 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Scan image
+        id: scan
+        uses: anchore/scan-action@v3
+        with:
+          image: ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}
+          acs-report-enable: true
+          # TODO(jaosorior): Fail build once we migrate off CentOS.
+          fail-build: false
+
       - name: Sign the images with GitHub OIDC Token
         run: cosign sign --recursive --yes ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: true
 
-      - name: Scan image
-        id: scan
-        uses: anchore/scan-action@v3
+      - name: Push Images Again
+        id: dockerpush
+        uses: docker/build-push-action@v4
         with:
-          image: ghcr.io/metal-toolbox/ironlib:latest
-          acs-report-enable: true
-          # TODO(jaosorior): Fail build once we migrate off CentOS.
-          fail-build: false
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
 
       - uses: anchore/sbom-action/download-syft@v0.14.1
 


### PR DESCRIPTION
### What does this PR do

Re-pushes to GHCR after images are signed. Hopefully this causes GHCR to end up with a valid image manifest, up until now all of them have been weird/broken.