### PR TITLE
.github/workflows/release-docker-image.yml: Disable cosign

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -34,8 +34,8 @@ jobs:
             type=semver,pattern={{raw}}
             type=sha
 
-      - name: install cosign
-        uses: sigstore/cosign-installer@main
+      # - name: install cosign
+      #   uses: sigstore/cosign-installer@main
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -65,10 +65,10 @@ jobs:
           # TODO(jaosorior): Fail build once we migrate off CentOS.
           fail-build: false
 
-      - name: Sign the images with GitHub OIDC Token
-        run: cosign sign --recursive --yes ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}
-        env:
-          COSIGN_EXPERIMENTAL: true
+      # - name: Sign the images with GitHub OIDC Token
+      #   run: cosign sign --recursive --yes ghcr.io/metal-toolbox/ironlib@${{ steps.dockerbuild.outputs.digest }}
+      #   env:
+      #     COSIGN_EXPERIMENTAL: true
 
       - name: Push Images Again
         id: dockerpush


### PR DESCRIPTION
### What does this PR do

Disables the docker image functionality provided by cosign in the github actions workflow.
