### PR TITLE
Dockerfile: Restate ARG TARGETOS TARGETARCH after FROM almalinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on \
     install -m 755 -D getbiosconfig /usr/sbin/
 
 FROM almalinux:9-minimal as stage1
+ARG TARGETOS TARGETARCH
 
 # copy ironlib wrapper binaries
 COPY --from=stage0 /usr/sbin/getbiosconfig /usr/sbin/getbiosconfig


### PR DESCRIPTION
### What does this PR do

Defines TARGETARCH after layering the almalinux:0-minimal image within Dockerfile.