### PR TITLE
Use metal-toolbox version of flashrom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,9 @@ RUN microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 \
     pciutils      \
     smartmontools \
     tar           \
+    udev          \
     unzip         \
     util-linux    \
-    flashrom      \
     python        \
     python-devel  \
     python-pip  \
@@ -86,6 +86,9 @@ RUN microdnf install -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 \
 
 RUN pip install uefi_firmware==v1.11
 
+# Install our custom flashrom package
+ADD https://github.com/metal-toolbox/flashrom/releases/download/v1.3.99/flashrom-1.3.99-0.el9.x86_64.rpm /tmp
+RUN rpm -ivh /tmp/flashrom*.rpm
 
 # Delete /tmp/* as we don't need those included in the image.
 RUN rm -rf /tmp/*


### PR DESCRIPTION
### What does this PR do

Use https://github.com/metal-toolbox/flashrom/releases/tag/v1.3.99

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

### How can this change be tested by a PR reviewer?

Test if the newer flashrom binary works better.

### Description for changelog/release notes

Updated flashrom with patches from metal-toolbox