### PR TITLE
Only ship flashrom on x86_64 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ RUN pip install uefi_firmware==v1.11
 
 # Install our custom flashrom package
 ADD https://github.com/metal-toolbox/flashrom/releases/download/v1.3.99/flashrom-1.3.99-0.el9.x86_64.rpm /tmp
-RUN rpm -ivh /tmp/flashrom*.rpm
+RUN if [[ $TARGETARCH = "amd64" ]] ; then \
+    rpm -ivh /tmp/flashrom*.rpm ; fi
 
 # Delete /tmp/* as we don't need those included in the image.
 RUN rm -rf /tmp/*


### PR DESCRIPTION
### What does this PR do
Only ship flashrom on x86_64 for now to unbreak the ARM builds.

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

### How can this change be tested by a PR reviewer?

### Description for changelog/release notes
