### PR TITLE
Vc/instrument firmware

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,8 +44,6 @@ linters-settings:
       - wrapperFunc
   gofumpt:
     extra-rules: true
-  wsl:
-    auto-fix: true
 
 linters:
   enable:
@@ -72,7 +70,6 @@ linters:
     - noctx
     - stylecheck
     - whitespace
-    - wsl
   enable-all: false
   disable-all: true
 

--- a/actions/inventory_test.go
+++ b/actions/inventory_test.go
@@ -11,6 +11,7 @@ import (
 	smcFixtures "github.com/metal-toolbox/ironlib/fixtures/supermicro"
 	"github.com/metal-toolbox/ironlib/model"
 	"github.com/metal-toolbox/ironlib/utils"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +47,7 @@ func Test_Inventory_dell(t *testing.T) {
 		WithDisabledCollectorUtilities([]model.CollectorUtility{"dmidecode"}),
 	}
 
-	collector := NewInventoryCollectorAction(options...)
+	collector := NewInventoryCollectorAction(logrus.New(), options...)
 	if err := collector.Collect(context.TODO(), &device); err != nil {
 		t.Error(err)
 	}
@@ -123,7 +124,7 @@ func Test_Inventory_smc(t *testing.T) {
 		StorageControllerCollectors: []StorageControllerCollector{storecli},
 	}
 
-	collector := NewInventoryCollectorAction(WithCollectors(collectors), WithTraceLevel())
+	collector := NewInventoryCollectorAction(logrus.New(), WithCollectors(collectors), WithTraceLevel())
 	if err := collector.Collect(context.TODO(), &device); err != nil {
 		t.Error(err)
 	}
@@ -186,7 +187,7 @@ func TestNewInventoryCollectorAction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewInventoryCollectorAction(tt.options...)
+			got := NewInventoryCollectorAction(logrus.New(), tt.options...)
 
 			switch tt.name {
 			case "trace-enabled":

--- a/examples/inventory/inventory.go
+++ b/examples/inventory/inventory.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	logger := logrus.New()
+	logger.Formatter = new(logrus.JSONFormatter)
 	device, err := ironlib.New(logger)
 	if err != nil {
 		logger.Fatal(err)

--- a/examples/inventory/inventory.go
+++ b/examples/inventory/inventory.go
@@ -15,6 +15,7 @@ import (
 func main() {
 	logger := logrus.New()
 	logger.Formatter = new(logrus.JSONFormatter)
+	logger.SetLevel(logrus.TraceLevel)
 	device, err := ironlib.New(logger)
 	if err != nil {
 		logger.Fatal(err)

--- a/providers/asrockrack/asrockrack.go
+++ b/providers/asrockrack/asrockrack.go
@@ -57,7 +57,7 @@ func (a *asrockrack) GetInventory(ctx context.Context, options ...actions.Option
 	deviceObj := common.NewDevice()
 	a.hw.Device = &deviceObj
 
-	collector := actions.NewInventoryCollectorAction(options...)
+	collector := actions.NewInventoryCollectorAction(a.logger, options...)
 	if err := collector.Collect(ctx, a.hw.Device); err != nil {
 		return nil, err
 	}

--- a/providers/dell/dell.go
+++ b/providers/dell/dell.go
@@ -116,7 +116,7 @@ func (d *dell) GetInventory(ctx context.Context, options ...actions.Option) (*co
 	// Collect device inventory
 	d.logger.Info("Collecting hardware inventory")
 
-	collector := actions.NewInventoryCollectorAction(options...)
+	collector := actions.NewInventoryCollectorAction(d.logger, options...)
 	if err := collector.Collect(ctx, d.hw.Device); err != nil {
 		return nil, err
 	}

--- a/providers/generic/generic.go
+++ b/providers/generic/generic.go
@@ -61,7 +61,7 @@ func (a *Generic) GetInventory(ctx context.Context, options ...actions.Option) (
 	// Collect device inventory
 	a.logger.Info("Collecting inventory")
 
-	collector := actions.NewInventoryCollectorAction(options...)
+	collector := actions.NewInventoryCollectorAction(a.logger, options...)
 	if err := collector.Collect(ctx, a.hw.Device); err != nil {
 		return nil, err
 	}

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -103,7 +103,7 @@ func (s *supermicro) GetInventory(ctx context.Context, options ...actions.Option
 
 	options = append(options, actions.WithCollectors(collectors))
 
-	collector := actions.NewInventoryCollectorAction(options...)
+	collector := actions.NewInventoryCollectorAction(s.logger, options...)
 	if err := collector.Collect(ctx, s.hw.Device); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
set the log level in the inventory example to `trace` so that we can follow along with the various tools.