### PR TITLE
ironlib is able to detect ineffective wipes

### DIFF
--- a/actions/storage_controller.go
+++ b/actions/storage_controller.go
@@ -102,8 +102,10 @@ func (s *StorageControllerAction) WipeDisk(ctx context.Context, logicalName stri
 	}
 	// Watermark disk
 	log.Printf("%s | Initiating watermarking process", logicalName)
-	check := utils.ApplyWatermarks(logicalName)
-
+	check, err := utils.ApplyWatermarks(logicalName)
+	if err != nil {
+		return err
+	}
 	err = util.WipeDisk(ctx, logicalName)
 	if err != nil {
 		return err

--- a/actions/storage_controller.go
+++ b/actions/storage_controller.go
@@ -13,10 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	ErrVirtualDiskManagerUtilNotIdentified = errors.New("virtual disk management utility not identifed")
-	ErrWipeVerificationNotSatisfactory     = errors.New("ineffective wipe")
-)
+var ErrVirtualDiskManagerUtilNotIdentified = errors.New("virtual disk management utility not identifed")
 
 type StorageControllerAction struct {
 	Logger *logrus.Logger
@@ -104,18 +101,18 @@ func (s *StorageControllerAction) WipeDisk(ctx context.Context, logicalName stri
 		return err
 	}
 	// Watermark disk
-	check, err := utils.PrepWatermarks(logicalName)
-	if err != nil {
-		return err
-	}
+	log.Printf("%s | Initiating watermarking process", logicalName)
+	check := utils.ApplyWatermarks(logicalName)
 
 	err = util.WipeDisk(ctx, logicalName)
 	if err != nil {
 		return err
 	}
-
-	if check() {
-		return nil
+	log.Printf("%s | Checking if the watermark has been removed", logicalName)
+	err = check()
+	if err != nil {
+		return err
 	}
-	return errors.Wrap(ErrWipeVerificationNotSatisfactory, "Watermark still present, disk not wipped")
+	log.Printf("%s | Watermarks has been removed", logicalName)
+	return nil
 }

--- a/actions/storage_controller.go
+++ b/actions/storage_controller.go
@@ -13,7 +13,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var ErrVirtualDiskManagerUtilNotIdentified = errors.New("virtual disk management utility not identifed")
+var (
+	ErrVirtualDiskManagerUtilNotIdentified = errors.New("virtual disk management utility not identifed")
+	ErrWipeVerificationNotSatisfactory     = errors.New("ineffective wipe")
+)
 
 type StorageControllerAction struct {
 	Logger *logrus.Logger
@@ -100,6 +103,19 @@ func (s *StorageControllerAction) WipeDisk(ctx context.Context, logicalName stri
 	if err != nil {
 		return err
 	}
+	// Watermark disk
+	check, err := utils.PrepWatermarks(logicalName)
+	if err != nil {
+		return err
+	}
 
-	return util.WipeDisk(ctx, logicalName)
+	err = util.WipeDisk(ctx, logicalName)
+	if err != nil {
+		return err
+	}
+
+	if check() {
+		return nil
+	}
+	return errors.Wrap(ErrWipeVerificationNotSatisfactory, "Watermark still present, disk not wipped")
 }

--- a/actions/storage_controller.go
+++ b/actions/storage_controller.go
@@ -101,20 +101,24 @@ func (s *StorageControllerAction) WipeDisk(ctx context.Context, logicalName stri
 		return err
 	}
 	// Watermark disk
+	// Before wiping the disk, we apply watermarks to later verify successful deletion
 	log.Printf("%s | Initiating watermarking process", logicalName)
 	check, err := utils.ApplyWatermarks(logicalName)
 	if err != nil {
 		return err
 	}
+	// Wipe the disk
 	err = util.WipeDisk(ctx, logicalName)
 	if err != nil {
 		return err
 	}
+	// Check if the watermark has been removed after wiping
 	log.Printf("%s | Checking if the watermark has been removed", logicalName)
 	err = check()
 	if err != nil {
 		return err
 	}
+	// Watermarks have been successfully removed, indicating successful deletion
 	log.Printf("%s | Watermarks has been removed", logicalName)
 	return nil
 }

--- a/examples/diskwipe/main.go
+++ b/examples/diskwipe/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/metal-toolbox/ironlib/actions"
@@ -22,5 +21,5 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	fmt.Println("Wiped successfully!")
+	logger.Println("Wiped successfully!")
 }

--- a/examples/diskwipe/main.go
+++ b/examples/diskwipe/main.go
@@ -22,5 +22,5 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	fmt.Println("Wiped")
+	fmt.Println("Wiped successfully!")
 }

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -1,0 +1,105 @@
+package utils
+
+import (
+	"crypto/rand"
+	"io"
+	"log"
+	"math/big"
+	"os"
+	"slices"
+)
+
+const (
+	bufferSize    = 512
+	numWatermarks = 10
+)
+
+type watermark struct {
+	position uint64
+	data     []byte
+}
+
+func PrepWatermarks(disk string) (func() bool, error) {
+	log.Printf("%s | Initiating watermarking process", disk)
+	watermarks := make([]watermark, numWatermarks)
+
+	// Write open
+	file, err := os.OpenFile(disk, os.O_WRONLY, 0)
+	if err != nil {
+		log.Printf("%s | Failed to open disk, err: %s", disk, err)
+		return nil, err
+	}
+	defer file.Close()
+
+	// Get disk or partition size
+	fileSize, err := file.Seek(0, io.SeekEnd)
+	if err != nil {
+		log.Printf("%s | Failed to get size, err: %s", disk, err)
+		return nil, err
+	}
+	// Write watermarks on random locations
+	err = writeWatermarks(file, fileSize, watermarks)
+	if err != nil {
+		log.Printf("%s | Failed to write watermarks, err: %s", disk, err)
+		return nil, err
+	}
+
+	checker := func() bool {
+		log.Printf("%s | Checking if the watermark has been removed", disk)
+
+		file, err := os.OpenFile(disk, os.O_RDONLY, 0)
+		if err != nil {
+			log.Printf("%s | Failed to open disk for reading: %s", disk, err)
+			return false
+		}
+		defer file.Close()
+
+		for _, watermark := range watermarks {
+			_, err = file.Seek(int64(watermark.position), io.SeekStart)
+			if err != nil {
+				log.Printf("%s | Error moving rw pointer: %s", disk, err)
+				return false
+			}
+			// Read the watermark written to the position
+			currentValue := make([]byte, bufferSize)
+			_, err = file.Read(currentValue)
+			if err != nil {
+				log.Printf("%s | Error reading from file: %s", disk, err)
+				return false
+			}
+			// Check if the watermark is still in the disk
+			if slices.Equal(currentValue, watermark.data) {
+				log.Printf("%s | Error existing watermark in the file", disk)
+				return false
+			}
+		}
+		log.Printf("%s | Watermarks has been removed", disk)
+		return true
+	}
+	return checker, nil
+}
+
+func writeWatermarks(file *os.File, fileSize int64, watermarks []watermark) error {
+	for i := 0; i < numWatermarks; i++ {
+		data := make([]byte, bufferSize)
+		_, err := rand.Read(data)
+		if err != nil {
+			log.Println("error:", err)
+			return err
+		}
+		randomPosition, err := rand.Int(rand.Reader, big.NewInt(fileSize))
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+
+		_, err = file.Seek(int64(randomPosition.Uint64()), io.SeekStart)
+		if err != nil {
+			log.Println("Error moving rw pointer:", err)
+			return err
+		}
+		watermarks[i].position = randomPosition.Uint64()
+		watermarks[i].data = data
+	}
+	return nil
+}

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -21,6 +21,9 @@ type watermark struct {
 	data     []byte
 }
 
+// ApplyWatermarks applies watermarks to the specified disk.
+// It returns a function that checks if the applied watermarks still exist on the file.
+// It relies on the writeWatermarks function to uniformly write watermarks across the disk.
 func ApplyWatermarks(logicalName string) (func() error, error) {
 	// Write open
 	file, err := os.OpenFile(logicalName, os.O_WRONLY, 0)
@@ -66,7 +69,7 @@ func ApplyWatermarks(logicalName string) (func() error, error) {
 			// Check if the watermark is still in the disk
 			if slices.Equal(currentValue, watermark.data) {
 				ErrorExistingWatermark := errors.New("Error existing watermark in the position: ")
-				return fmt.Errorf("%s | %w %d", logicalName, ErrorExistingWatermark, watermark.position)
+				return fmt.Errorf("%s@%d | %w", logicalName, watermark.position, ErrorExistingWatermark)
 			}
 		}
 		return nil

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -34,6 +34,11 @@ func ApplyWatermarks(logicalName string) (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if fileSize == 0 {
+		return nil, errors.New("No space for watermarking")
+	}
+
 	// Write watermarks on random locations
 	watermarks, err := writeWatermarks(file, fileSize, numWatermarks)
 	if err != nil {
@@ -60,8 +65,8 @@ func ApplyWatermarks(logicalName string) (func() error, error) {
 			}
 			// Check if the watermark is still in the disk
 			if slices.Equal(currentValue, watermark.data) {
-				ErrorExistingWatermark := errors.New("Error existing watermark in the file")
-				return fmt.Errorf("%s | %w", logicalName, ErrorExistingWatermark)
+				ErrorExistingWatermark := errors.New("Error existing watermark in the position: ")
+				return fmt.Errorf("%s | %w %d", logicalName, ErrorExistingWatermark, watermark.position)
 			}
 		}
 		return nil


### PR DESCRIPTION
### What does this PR do
Disks lie about supporting standard commands and/or successful completion of those commands, so we need to “trust but verify”. We have definitely seen this before, most recently with some micron nvme disks that respond successfully to TRIM commands but do not actually wipe the data

### How can this change be tested by a PR reviewer?
Added in examples/diskwipe/main.go

### Description for changelog/release notes
ironlib is able to detect ineffective wipes
