### PR TITLE
More refactors, fixes, etc

### DIFF
--- a/providers/dell/helpers.go
+++ b/providers/dell/helpers.go
@@ -81,7 +81,7 @@ func (d *dell) installUpdate(ctx context.Context, updateFile string, downgrade b
 		logrus.Fields{"file": updateFile},
 	).Info("Installing dell Update Bin file")
 
-	result, err := e.ExecWithContext(ctx)
+	result, err := e.Exec(ctx)
 	if err != nil {
 		return result.ExitCode, err
 	}
@@ -206,7 +206,7 @@ func (d *dell) startSrvHelper(ctx context.Context) error {
 	e := utils.NewExecutor("/usr/libexec/instsvcdrv-helper")
 	e.SetArgs("start")
 
-	result, err := e.ExecWithContext(ctx)
+	result, err := e.Exec(ctx)
 
 	if err != nil || result.ExitCode != 0 {
 		return err

--- a/providers/dell/helpers.go
+++ b/providers/dell/helpers.go
@@ -71,7 +71,7 @@ func (d *dell) installUpdate(ctx context.Context, updateFile string, downgrade b
 	}
 
 	e := utils.NewExecutor(updateFile)
-	e.SetArgs(args)
+	e.SetArgs(args...)
 
 	if d.logger.Level >= logrus.TraceLevel {
 		e.SetVerbose()
@@ -204,7 +204,7 @@ func (d *dell) startSrvHelper(ctx context.Context) error {
 	}
 
 	e := utils.NewExecutor("/usr/libexec/instsvcdrv-helper")
-	e.SetArgs([]string{"start"})
+	e.SetArgs("start")
 
 	result, err := e.ExecWithContext(ctx)
 

--- a/utils/asrr_bioscontrol.go
+++ b/utils/asrr_bioscontrol.go
@@ -77,7 +77,7 @@ func (a *AsrrBioscontrol) Attributes() (utilName model.CollectorUtility, absolut
 // kernelVersion returns the host kernel version
 func kernelVersion(ctx context.Context) (string, error) {
 	unameExec := NewExecutor("uname")
-	unameExec.SetArgs([]string{"-r"})
+	unameExec.SetArgs("-r")
 	unameExec.SetQuiet()
 
 	r, err := unameExec.ExecWithContext(ctx)
@@ -140,7 +140,7 @@ func loadAsrrBiosKernelModule(ctx context.Context) error {
 
 	// 3. depmod to rebuild /lib/modules/$(uname -r)/modules.dep
 	depmodExec := NewExecutor("depmod")
-	depmodExec.SetArgs([]string{"-a"})
+	depmodExec.SetArgs("-a")
 	depmodExec.SetQuiet()
 
 	_, err = depmodExec.ExecWithContext(ctx)
@@ -150,7 +150,7 @@ func loadAsrrBiosKernelModule(ctx context.Context) error {
 
 	// 4. load module
 	modprobeExec := NewExecutor("modprobe")
-	modprobeExec.SetArgs([]string{"asrdev"})
+	modprobeExec.SetArgs("asrdev")
 	modprobeExec.SetQuiet()
 
 	_, err = modprobeExec.ExecWithContext(ctx)
@@ -171,7 +171,7 @@ func (a *AsrrBioscontrol) GetBIOSConfiguration(ctx context.Context, _ string) (m
 		return nil, err
 	}
 
-	a.Executor.SetArgs([]string{"/g", a.tmpJSONFile})
+	a.Executor.SetArgs("/g", a.tmpJSONFile)
 
 	_, err = a.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/asrr_bioscontrol.go
+++ b/utils/asrr_bioscontrol.go
@@ -80,7 +80,7 @@ func kernelVersion(ctx context.Context) (string, error) {
 	unameExec.SetArgs("-r")
 	unameExec.SetQuiet()
 
-	r, err := unameExec.ExecWithContext(ctx)
+	r, err := unameExec.Exec(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "error executing uname -r")
 	}
@@ -93,7 +93,7 @@ func kernelModuleLoaded(ctx context.Context, name string) (bool, error) {
 	lsmodExec := NewExecutor("lsmod")
 	lsmodExec.SetQuiet()
 
-	r, err := lsmodExec.ExecWithContext(ctx)
+	r, err := lsmodExec.Exec(ctx)
 	if err != nil {
 		return false, errors.Wrap(err, "error executing lsmod")
 	}
@@ -143,7 +143,7 @@ func loadAsrrBiosKernelModule(ctx context.Context) error {
 	depmodExec.SetArgs("-a")
 	depmodExec.SetQuiet()
 
-	_, err = depmodExec.ExecWithContext(ctx)
+	_, err = depmodExec.Exec(ctx)
 	if err != nil {
 		return errors.Wrap(err, ErrASRRBIOSKernelModule.Error())
 	}
@@ -153,7 +153,7 @@ func loadAsrrBiosKernelModule(ctx context.Context) error {
 	modprobeExec.SetArgs("asrdev")
 	modprobeExec.SetQuiet()
 
-	_, err = modprobeExec.ExecWithContext(ctx)
+	_, err = modprobeExec.Exec(ctx)
 	if err != nil {
 		return errors.Wrap(err, ErrASRRBIOSKernelModule.Error())
 	}
@@ -173,7 +173,7 @@ func (a *AsrrBioscontrol) GetBIOSConfiguration(ctx context.Context, _ string) (m
 
 	a.Executor.SetArgs("/g", a.tmpJSONFile)
 
-	_, err = a.Executor.ExecWithContext(ctx)
+	_, err = a.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/dell_racadm.go
+++ b/utils/dell_racadm.go
@@ -92,7 +92,7 @@ func (s *DellRacadm) racadmBIOSConfigXML(ctx context.Context) (map[string]string
 	// a two-step process, and read the tempfile during the parsing step.
 
 	s.Executor.SetArgs("get", "-t", "xml", "-f", s.BIOSCfgTmpFile)
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (s *DellRacadm) racadmBIOSConfigJSON(ctx context.Context) (map[string]strin
 	// a two-step process, and read the tempfile during the parsing step.
 
 	s.Executor.SetArgs("get", "-t", "json", "-f", s.BIOSCfgTmpFile)
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -206,8 +206,8 @@ func NewFakeRacadm(biosCfgFile string) *DellRacadm {
 	return &DellRacadm{Executor: executor, BIOSCfgTmpFile: biosCfgFile, KeepConfigFile: true}
 }
 
-// ExecWithContext implements the utils.Executor interface
-func (e *FakeRacadmExecute) ExecWithContext(context.Context) (*Result, error) {
+// Exec implements the utils.Executor interface
+func (e *FakeRacadmExecute) Exec(context.Context) (*Result, error) {
 	return &Result{Stdout: []byte(`dummy`)}, nil
 }
 

--- a/utils/dell_racadm.go
+++ b/utils/dell_racadm.go
@@ -90,9 +90,8 @@ func (s *DellRacadm) racadmBIOSConfigXML(ctx context.Context) (map[string]string
 	// Dump the current BIOS config to dellBiosTempFilename. The racadm
 	// command won't dump the config to stdout directly, so we do this in
 	// a two-step process, and read the tempfile during the parsing step.
-	cmd := []string{"get", "-t", "xml", "-f", s.BIOSCfgTmpFile}
-	s.Executor.SetArgs(cmd)
 
+	s.Executor.SetArgs("get", "-t", "xml", "-f", s.BIOSCfgTmpFile)
 	result, err := s.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return nil, err
@@ -141,9 +140,8 @@ func (s *DellRacadm) racadmBIOSConfigJSON(ctx context.Context) (map[string]strin
 	// Dump the current BIOS config to dellBiosTempFilename. The racadm
 	// command won't dump the config to stdout directly, so we do this in
 	// a two-step process, and read the tempfile during the parsing step.
-	cmd := []string{"get", "-t", "json", "-f", s.BIOSCfgTmpFile}
-	s.Executor.SetArgs(cmd)
 
+	s.Executor.SetArgs("get", "-t", "json", "-f", s.BIOSCfgTmpFile)
 	result, err := s.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return nil, err
@@ -214,6 +212,6 @@ func (e *FakeRacadmExecute) ExecWithContext(context.Context) (*Result, error) {
 }
 
 // SetArgs is to set cmd args to the fake execute method
-func (e *FakeRacadmExecute) SetArgs(a []string) {
+func (e *FakeRacadmExecute) SetArgs(a ...string) {
 	e.Args = a
 }

--- a/utils/dnf.go
+++ b/utils/dnf.go
@@ -121,8 +121,7 @@ func (d *Dnf) Install(pkgNames []string) (err error) {
 	args := []string{"install", "-y"}
 	args = append(args, pkgNames...)
 
-	d.Executor.SetArgs(args)
-
+	d.Executor.SetArgs(args...)
 	_, err = d.Executor.ExecWithContext(context.Background())
 
 	return err

--- a/utils/dnf.go
+++ b/utils/dnf.go
@@ -122,7 +122,7 @@ func (d *Dnf) Install(pkgNames []string) (err error) {
 	args = append(args, pkgNames...)
 
 	d.Executor.SetArgs(args...)
-	_, err = d.Executor.ExecWithContext(context.Background())
+	_, err = d.Executor.Exec(context.Background())
 
 	return err
 }

--- a/utils/dsu.go
+++ b/utils/dsu.go
@@ -97,7 +97,7 @@ func (d *Dsu) FetchUpdateFiles(ctx context.Context, dstDir string) (int, error) 
 	// because... yeah dsu wants to fetch updates interactively
 	d.Executor.SetStdin(bytes.NewReader([]byte("a\nc\n")))
 
-	result, err := d.Executor.ExecWithContext(ctx)
+	result, err := d.Executor.Exec(ctx)
 
 	return result.ExitCode, err
 }
@@ -131,7 +131,7 @@ func (d *Dsu) ApplyLocalUpdates(ctx context.Context, updateDir string) (int, err
 
 	// dsu --log-level=4 --non-interactive --source-type=REPOSITORY --source-location=/root/dsu/dellupdates --ic-location=/root/dsu/dellupdates/invcol_5N2WM_LN64_20_09_200_921_A00.BIN
 	d.Executor.SetArgs("--non-interactive", "--log-level=4", "--source-type=REPOSITORY", "--source-location="+updateDir, "--ic-location="+invcol)
-	result, err := d.Executor.ExecWithContext(ctx)
+	result, err := d.Executor.Exec(ctx)
 
 	return result.ExitCode, err
 }
@@ -140,7 +140,7 @@ func (d *Dsu) ApplyLocalUpdates(ctx context.Context, updateDir string) (int, err
 // updates device component firmware based on data listed by the dell system update tool
 func (d *Dsu) Inventory(ctx context.Context) ([]*model.Component, error) {
 	d.Executor.SetArgs("--import-public-key", "--inventory")
-	result, err := d.Executor.ExecWithContext(ctx)
+	result, err := d.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (d *Dsu) Inventory(ctx context.Context) ([]*model.Component, error) {
 // Returns component firmware updates available based on the dell system update
 func (d *Dsu) ComponentFirmwareUpdatePreview(ctx context.Context) ([]*model.Component, int, error) {
 	d.Executor.SetArgs("--import-public-key", "--preview")
-	result, err := d.Executor.ExecWithContext(ctx)
+	result, err := d.Executor.Exec(ctx)
 	if err != nil {
 		return nil, result.ExitCode, err
 	}
@@ -167,7 +167,7 @@ func (d *Dsu) ComponentFirmwareUpdatePreview(ctx context.Context) ([]*model.Comp
 // ApplyUpdates installs all available updates
 func (d *Dsu) ApplyUpdates() (int, error) {
 	d.Executor.SetArgs("--non-interactive", "--log-level=4")
-	result, err := d.Executor.ExecWithContext(context.Background())
+	result, err := d.Executor.Exec(context.Background())
 	// our executor returns err if exitcode is not zero
 	// 34 - no updates applicable
 	return result.ExitCode, err
@@ -179,7 +179,7 @@ func (d *Dsu) Version() (string, error) {
 	e.SetArgs("-q", "dell-system-update", "--queryformat=%{VERSION}-%{RELEASE}")
 	e.SetVerbose()
 
-	result, err := e.ExecWithContext(context.Background())
+	result, err := e.Exec(context.Background())
 	if err != nil {
 		// our executor returns err if exitcode is not zero
 		return "", errors.Wrap(ErrDsuVersionQuery, err.Error())

--- a/utils/dsu.go
+++ b/utils/dsu.go
@@ -92,7 +92,7 @@ func (d *Dsu) FetchUpdateFiles(ctx context.Context, dstDir string) (int, error) 
 	// purge any existing update file/directory with the same name
 	_ = os.Remove(dstDir)
 
-	d.Executor.SetArgs([]string{"--destination-type=CBD", "--destination-location=" + dstDir})
+	d.Executor.SetArgs("--destination-type=CBD", "--destination-location="+dstDir)
 
 	// because... yeah dsu wants to fetch updates interactively
 	d.Executor.SetStdin(bytes.NewReader([]byte("a\nc\n")))
@@ -130,16 +130,7 @@ func (d *Dsu) ApplyLocalUpdates(ctx context.Context, updateDir string) (int, err
 	updateDir = filepath.Dir(invcol)
 
 	// dsu --log-level=4 --non-interactive --source-type=REPOSITORY --source-location=/root/dsu/dellupdates --ic-location=/root/dsu/dellupdates/invcol_5N2WM_LN64_20_09_200_921_A00.BIN
-	d.Executor.SetArgs(
-		[]string{
-			"--non-interactive",
-			"--log-level=4",
-			"--source-type=REPOSITORY",
-			"--source-location=" + updateDir,
-			"--ic-location=" + invcol,
-		},
-	)
-
+	d.Executor.SetArgs("--non-interactive", "--log-level=4", "--source-type=REPOSITORY", "--source-location="+updateDir, "--ic-location="+invcol)
 	result, err := d.Executor.ExecWithContext(ctx)
 
 	return result.ExitCode, err
@@ -148,8 +139,7 @@ func (d *Dsu) ApplyLocalUpdates(ctx context.Context, updateDir string) (int, err
 // Inventory collects inventory with the dell-system-update utility and
 // updates device component firmware based on data listed by the dell system update tool
 func (d *Dsu) Inventory(ctx context.Context) ([]*model.Component, error) {
-	d.Executor.SetArgs([]string{"--import-public-key", "--inventory"})
-
+	d.Executor.SetArgs("--import-public-key", "--inventory")
 	result, err := d.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return nil, err
@@ -165,8 +155,7 @@ func (d *Dsu) Inventory(ctx context.Context) ([]*model.Component, error) {
 
 // Returns component firmware updates available based on the dell system update
 func (d *Dsu) ComponentFirmwareUpdatePreview(ctx context.Context) ([]*model.Component, int, error) {
-	d.Executor.SetArgs([]string{"--import-public-key", "--preview"})
-
+	d.Executor.SetArgs("--import-public-key", "--preview")
 	result, err := d.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return nil, result.ExitCode, err
@@ -177,9 +166,7 @@ func (d *Dsu) ComponentFirmwareUpdatePreview(ctx context.Context) ([]*model.Comp
 
 // ApplyUpdates installs all available updates
 func (d *Dsu) ApplyUpdates() (int, error) {
-	args := []string{"--non-interactive", "--log-level=4"}
-	d.Executor.SetArgs(args)
-
+	d.Executor.SetArgs("--non-interactive", "--log-level=4")
 	result, err := d.Executor.ExecWithContext(context.Background())
 	// our executor returns err if exitcode is not zero
 	// 34 - no updates applicable
@@ -189,7 +176,7 @@ func (d *Dsu) ApplyUpdates() (int, error) {
 // Version returns the dsu currently installed
 func (d *Dsu) Version() (string, error) {
 	e := NewExecutor("rpm")
-	e.SetArgs([]string{"-q", "dell-system-update", "--queryformat=%{VERSION}-%{RELEASE}"})
+	e.SetArgs("-q", "dell-system-update", "--queryformat=%{VERSION}-%{RELEASE}")
 	e.SetVerbose()
 
 	result, err := e.ExecWithContext(context.Background())

--- a/utils/dsu_test.go
+++ b/utils/dsu_test.go
@@ -48,7 +48,7 @@ func Test_dsuParseInventoryBytes(t *testing.T) {
 
 	d.Executor.SetArgs("--import-public-key", "--inventory")
 
-	result, err := d.Executor.ExecWithContext(context.Background())
+	result, err := d.Executor.Exec(context.Background())
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -70,7 +70,7 @@ func Test_dsuParsePreviewBytes(t *testing.T) {
 		t.Error(err)
 	}
 
-	result, err := d.Executor.ExecWithContext(context.Background())
+	result, err := d.Executor.Exec(context.Background())
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/utils/dsu_test.go
+++ b/utils/dsu_test.go
@@ -46,7 +46,7 @@ func Test_dsuParseInventoryBytes(t *testing.T) {
 		t.Error(err)
 	}
 
-	d.Executor.SetArgs([]string{"--import-public-key", "--inventory"})
+	d.Executor.SetArgs("--import-public-key", "--inventory")
 
 	result, err := d.Executor.ExecWithContext(context.Background())
 	if err != nil {

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -15,7 +15,7 @@ import (
 // Executor interface lets us implement dummy executors for tests
 type Executor interface {
 	ExecWithContext(context.Context) (*Result, error)
-	SetArgs([]string)
+	SetArgs(...string)
 	SetEnv([]string)
 	SetQuiet()
 	SetVerbose()
@@ -66,7 +66,7 @@ func (e *Execute) CmdPath() string {
 }
 
 // SetArgs sets the command args
-func (e *Execute) SetArgs(a []string) {
+func (e *Execute) SetArgs(a ...string) {
 	e.Args = a
 }
 

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -14,7 +14,7 @@ import (
 
 // Executor interface lets us implement dummy executors for tests
 type Executor interface {
-	ExecWithContext(context.Context) (*Result, error)
+	Exec(context.Context) (*Result, error)
 	SetArgs(...string)
 	SetEnv([]string)
 	SetQuiet()
@@ -107,8 +107,8 @@ func (e *Execute) SetStderr(_ []byte) {
 func (e *Execute) SetExitCode(_ int) {
 }
 
-// ExecWithContext executes the command and returns the Result object
-func (e *Execute) ExecWithContext(ctx context.Context) (result *Result, err error) {
+// Exec executes the command and returns the Result object
+func (e *Execute) Exec(ctx context.Context) (result *Result, err error) {
 	if e.CheckBin {
 		err = e.CheckExecutable()
 		if err != nil {

--- a/utils/executor_test.go
+++ b/utils/executor_test.go
@@ -20,7 +20,7 @@ func Test_Stdin(t *testing.T) {
 	e.Stdin = bytes.NewReader([]byte("hello"))
 	e.SetQuiet()
 
-	result, err := e.ExecWithContext(context.Background())
+	result, err := e.Exec(context.Background())
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/utils/fake_executor.go
+++ b/utils/fake_executor.go
@@ -29,7 +29,7 @@ func NewFakeExecutor(cmd string) Executor {
 // nolint:gocyclo // TODO: break this method up and move into each $util_test.go
 // FakeExecute method returns whatever you want it to return
 // Set e.Stdout and e.Stderr to data to be returned
-func (e *FakeExecute) ExecWithContext(_ context.Context) (*Result, error) {
+func (e *FakeExecute) Exec(_ context.Context) (*Result, error) {
 	switch e.Cmd {
 	case "ipmicfg":
 		if e.Args[0] == "-summary" {

--- a/utils/fake_executor.go
+++ b/utils/fake_executor.go
@@ -140,7 +140,7 @@ func (e *FakeExecute) CmdPath() string {
 	return e.Cmd
 }
 
-func (e *FakeExecute) SetArgs(a []string) {
+func (e *FakeExecute) SetArgs(a ...string) {
 	e.Args = a
 }
 

--- a/utils/flashrom.go
+++ b/utils/flashrom.go
@@ -45,7 +45,7 @@ func (f *Flashrom) Attributes() (utilName model.CollectorUtility, absolutePath s
 // ExtractBIOSImage writes the BIOS image to the given file system path.
 func (f *Flashrom) WriteBIOSImage(ctx context.Context, path string) error {
 	// flashrom -p internal --ifd -i bios -r /tmp/bios_region.img
-	f.Executor.SetArgs([]string{"-p", "internal", "--ifd", "-i", "bios", "-r", path})
+	f.Executor.SetArgs("-p", "internal", "--ifd", "-i", "bios", "-r", path)
 
 	_, err := f.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/flashrom.go
+++ b/utils/flashrom.go
@@ -47,7 +47,7 @@ func (f *Flashrom) WriteBIOSImage(ctx context.Context, path string) error {
 	// flashrom -p internal --ifd -i bios -r /tmp/bios_region.img
 	f.Executor.SetArgs("-p", "internal", "--ifd", "-i", "bios", "-r", path)
 
-	_, err := f.Executor.ExecWithContext(ctx)
+	_, err := f.Executor.Exec(ctx)
 	if err != nil {
 		return err
 	}

--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -50,7 +50,7 @@ func (h *Hdparm) cmdListCapabilities(ctx context.Context, logicalName string) ([
 	// hdparm -I devicepath
 	h.Executor.SetArgs("-I", logicalName)
 
-	result, err := h.Executor.ExecWithContext(ctx)
+	result, err := h.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -48,7 +48,7 @@ func (h *Hdparm) Attributes() (utilName model.CollectorUtility, absolutePath str
 
 func (h *Hdparm) cmdListCapabilities(ctx context.Context, logicalName string) ([]byte, error) {
 	// hdparm -I devicepath
-	h.Executor.SetArgs([]string{"-I", logicalName})
+	h.Executor.SetArgs("-I", logicalName)
 
 	result, err := h.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/lsblk.go
+++ b/utils/lsblk.go
@@ -105,7 +105,7 @@ func (l *Lsblk) list(ctx context.Context) ([]byte, error) {
 	// lsblk --json --nodeps --output name,path,model,serial,tran -e1,7,11
 	l.Executor.SetArgs("--json", "--nodeps", "-p", "--output", "kname,name,model,serial,rev,tran", "-e1,7,11")
 
-	result, err := l.Executor.ExecWithContext(ctx)
+	result, err := l.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/lsblk.go
+++ b/utils/lsblk.go
@@ -103,7 +103,7 @@ func (l *Lsblk) Drives(ctx context.Context) ([]*common.Drive, error) {
 
 func (l *Lsblk) list(ctx context.Context) ([]byte, error) {
 	// lsblk --json --nodeps --output name,path,model,serial,tran -e1,7,11
-	l.Executor.SetArgs([]string{"--json", "--nodeps", "-p", "--output", "kname,name,model,serial,rev,tran", "-e1,7,11"})
+	l.Executor.SetArgs("--json", "--nodeps", "-p", "--output", "kname,name,model,serial,rev,tran", "-e1,7,11")
 
 	result, err := l.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/lshw.go
+++ b/utils/lshw.go
@@ -147,7 +147,7 @@ func (l *Lshw) ListJSON(ctx context.Context) (*LshwOutput, error) {
 	// lshw -json -notime
 	l.Executor.SetArgs("-json", "-notime", "-numeric")
 
-	result, err := l.Executor.ExecWithContext(ctx)
+	result, err := l.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -671,8 +671,8 @@ func NewFakeLshw(stdin io.Reader) *Lshw {
 	return &Lshw{Executor: executor, nicSerials: make(map[string]bool)}
 }
 
-// ExecWithContext implements the utils.Executor interface
-func (e *FakeLshwExecute) ExecWithContext(context.Context) (*Result, error) {
+// Exec implements the utils.Executor interface
+func (e *FakeLshwExecute) Exec(context.Context) (*Result, error) {
 	b := bytes.Buffer{}
 
 	_, err := b.ReadFrom(e.Stdin)

--- a/utils/lshw.go
+++ b/utils/lshw.go
@@ -145,7 +145,7 @@ func (l *Lshw) Collect(ctx context.Context, device *common.Device) error {
 // ListJSON returns the lshw output as a struct
 func (l *Lshw) ListJSON(ctx context.Context) (*LshwOutput, error) {
 	// lshw -json -notime
-	l.Executor.SetArgs([]string{"-json", "-notime", "-numeric"})
+	l.Executor.SetArgs("-json", "-notime", "-numeric")
 
 	result, err := l.Executor.ExecWithContext(ctx)
 	if err != nil {
@@ -689,6 +689,6 @@ func (e *FakeLshwExecute) SetStdin(r io.Reader) {
 }
 
 // SetArgs is to set cmd args to the fake execute method
-func (e *FakeLshwExecute) SetArgs(a []string) {
+func (e *FakeLshwExecute) SetArgs(a ...string) {
 	e.Args = a
 }

--- a/utils/mlxup.go
+++ b/utils/mlxup.go
@@ -166,7 +166,7 @@ func (m *Mlxup) UpdateNIC(ctx context.Context, updateFile, modelNumber string) e
 		}
 
 		m.Executor.SetArgs("--yes", "--dev", nic.PCIDeviceName, "--image-file", updateFile)
-		result, err := m.Executor.ExecWithContext(ctx)
+		result, err := m.Executor.Exec(ctx)
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func (m *Mlxup) Query(ctx context.Context) ([]*MlxupDevice, error) {
 	// mlxup --query
 	m.Executor.SetArgs("--query")
 
-	result, err := m.Executor.ExecWithContext(ctx)
+	result, err := m.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/mlxup.go
+++ b/utils/mlxup.go
@@ -165,14 +165,7 @@ func (m *Mlxup) UpdateNIC(ctx context.Context, updateFile, modelNumber string) e
 			}
 		}
 
-		m.Executor.SetArgs([]string{
-			"--yes",
-			"--dev",
-			nic.PCIDeviceName,
-			"--image-file",
-			updateFile,
-		})
-
+		m.Executor.SetArgs("--yes", "--dev", nic.PCIDeviceName, "--image-file", updateFile)
 		result, err := m.Executor.ExecWithContext(ctx)
 		if err != nil {
 			return err
@@ -189,7 +182,7 @@ func (m *Mlxup) UpdateNIC(ctx context.Context, updateFile, modelNumber string) e
 // Query returns a slice of mellanox devices
 func (m *Mlxup) Query(ctx context.Context) ([]*MlxupDevice, error) {
 	// mlxup --query
-	m.Executor.SetArgs([]string{"--query"})
+	m.Executor.SetArgs("--query")
 
 	result, err := m.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/mlxup_test.go
+++ b/utils/mlxup_test.go
@@ -107,7 +107,7 @@ func Test_MlxupParseQueryOutput(t *testing.T) {
 
 	cli.Executor.SetStdout(b)
 
-	result, err := cli.Executor.ExecWithContext(context.Background())
+	result, err := cli.Executor.Exec(context.Background())
 	if err != nil {
 		t.Error(err)
 	}

--- a/utils/msecli.go
+++ b/utils/msecli.go
@@ -145,7 +145,7 @@ func (m *Msecli) updateDrive(ctx context.Context, modelNumber, updateFile string
 		filepath.Dir(updateFile),
 	)
 
-	result, err := m.Executor.ExecWithContext(ctx)
+	result, err := m.Executor.Exec(ctx)
 	if err != nil {
 		return newExecError(m.Executor.GetCmd(), result)
 	}
@@ -161,7 +161,7 @@ func (m *Msecli) updateDrive(ctx context.Context, modelNumber, updateFile string
 func (m *Msecli) Query(ctx context.Context) ([]*MsecliDevice, error) {
 	m.Executor.SetArgs("-L")
 
-	result, err := m.Executor.ExecWithContext(ctx)
+	result, err := m.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/msecli.go
+++ b/utils/msecli.go
@@ -137,13 +137,12 @@ func (m *Msecli) UpdateDrive(ctx context.Context, updateFile, modelNumber, seria
 func (m *Msecli) updateDrive(ctx context.Context, modelNumber, updateFile string) error {
 	// echo 'y'
 	m.Executor.SetStdin(bytes.NewReader([]byte("y\n")))
-	m.Executor.SetArgs([]string{
+	m.Executor.SetArgs(
 		"-U", // update
 		"-m", // model
 		modelNumber,
 		"-i", // directory containing the update file
 		filepath.Dir(updateFile),
-	},
 	)
 
 	result, err := m.Executor.ExecWithContext(ctx)
@@ -160,7 +159,7 @@ func (m *Msecli) updateDrive(ctx context.Context, modelNumber, updateFile string
 
 // Query parses the output of mseli -L and returns a slice of *MsecliDevice's
 func (m *Msecli) Query(ctx context.Context) ([]*MsecliDevice, error) {
-	m.Executor.SetArgs([]string{"-L"})
+	m.Executor.SetArgs("-L")
 
 	result, err := m.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/msecli_test.go
+++ b/utils/msecli_test.go
@@ -88,7 +88,7 @@ func Test_parseMsecliQueryOutput(t *testing.T) {
 		t.Error(err)
 	}
 
-	m.Executor.SetArgs([]string{"-L"})
+	m.Executor.SetArgs("-L")
 
 	result, err := m.Executor.ExecWithContext(context.Background())
 	if err != nil {
@@ -108,7 +108,7 @@ func Test_parseMsecliQueryOutputCmdFailure(t *testing.T) {
 		t.Error(err)
 	}
 
-	m.Executor.SetArgs([]string{"-L"})
+	m.Executor.SetArgs("-L")
 
 	result, err := m.Executor.ExecWithContext(context.Background())
 	if err != nil {
@@ -127,7 +127,7 @@ func Test_QueryOutputEmpty(t *testing.T) {
 		t.Error(err)
 	}
 
-	m.Executor.SetArgs([]string{"-L"})
+	m.Executor.SetArgs("-L")
 
 	_, err = m.Query(context.Background())
 	assert.Equal(t, ErrNoCommandOutput, errors.Cause(err))

--- a/utils/msecli_test.go
+++ b/utils/msecli_test.go
@@ -90,7 +90,7 @@ func Test_parseMsecliQueryOutput(t *testing.T) {
 
 	m.Executor.SetArgs("-L")
 
-	result, err := m.Executor.ExecWithContext(context.Background())
+	result, err := m.Executor.Exec(context.Background())
 	if err != nil {
 		t.Error(err)
 	}
@@ -110,7 +110,7 @@ func Test_parseMsecliQueryOutputCmdFailure(t *testing.T) {
 
 	m.Executor.SetArgs("-L")
 
-	result, err := m.Executor.ExecWithContext(context.Background())
+	result, err := m.Executor.Exec(context.Background())
 	if err != nil {
 		t.Error(err)
 	}

--- a/utils/mvcli.go
+++ b/utils/mvcli.go
@@ -224,7 +224,7 @@ func (m *Mvcli) Info(ctx context.Context, infoType string) ([]*MvcliDevice, erro
 		return nil, InvalidInfoTypeError(infoType)
 	}
 
-	m.Executor.SetArgs([]string{"info", "-o", infoType})
+	m.Executor.SetArgs("info", "-o", infoType)
 
 	result, err := m.Executor.ExecWithContext(ctx)
 	if err != nil {
@@ -397,15 +397,9 @@ func (m *Mvcli) Create(ctx context.Context, physicalDiskIDs []uint, raidMode, na
 		return InvalidInitModeError(initMode)
 	}
 
-	m.Executor.SetArgs([]string{
-		"create",
-		"-o", "vd",
-		"-r", raidMode,
-		"-d", strings.Trim(strings.Join(strings.Fields(fmt.Sprint(physicalDiskIDs)), ","), "[]"),
-		"-n", name,
-		"-b", fmt.Sprintf("%d", blockSize),
-	})
+	devices := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(physicalDiskIDs)), ","), "[]")
 
+	m.Executor.SetArgs("create", "-o", "vd", "-r", raidMode, "-d", devices, "-n", name, "-b", fmt.Sprintf("%d", blockSize))
 	result, err := m.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return err
@@ -428,12 +422,8 @@ func (m *Mvcli) Create(ctx context.Context, physicalDiskIDs []uint, raidMode, na
 
 func (m *Mvcli) Destroy(ctx context.Context, virtualDiskID int) error {
 	m.Executor.SetStdin(bytes.NewReader([]byte("y\n")))
-	m.Executor.SetArgs([]string{
-		"delete",
-		"-o", "vd",
-		"-i", fmt.Sprintf("%d", virtualDiskID),
-	})
 
+	m.Executor.SetArgs("delete", "-o", "vd", "-i", fmt.Sprintf("%d", virtualDiskID))
 	result, err := m.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return err

--- a/utils/mvcli.go
+++ b/utils/mvcli.go
@@ -226,7 +226,7 @@ func (m *Mvcli) Info(ctx context.Context, infoType string) ([]*MvcliDevice, erro
 
 	m.Executor.SetArgs("info", "-o", infoType)
 
-	result, err := m.Executor.ExecWithContext(ctx)
+	result, err := m.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func (m *Mvcli) Create(ctx context.Context, physicalDiskIDs []uint, raidMode, na
 	devices := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(physicalDiskIDs)), ","), "[]")
 
 	m.Executor.SetArgs("create", "-o", "vd", "-r", raidMode, "-d", devices, "-n", name, "-b", fmt.Sprintf("%d", blockSize))
-	result, err := m.Executor.ExecWithContext(ctx)
+	result, err := m.Executor.Exec(ctx)
 	if err != nil {
 		return err
 	}
@@ -424,7 +424,7 @@ func (m *Mvcli) Destroy(ctx context.Context, virtualDiskID int) error {
 	m.Executor.SetStdin(bytes.NewReader([]byte("y\n")))
 
 	m.Executor.SetArgs("delete", "-o", "vd", "-i", fmt.Sprintf("%d", virtualDiskID))
-	result, err := m.Executor.ExecWithContext(ctx)
+	result, err := m.Executor.Exec(ctx)
 	if err != nil {
 		return err
 	}

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -179,6 +179,12 @@ func parseFna(fna uint) []*common.Capability {
 	// All names come from internal nvme-cli names
 	// We will *not* keep in sync as these names form our API
 	// https: // github.com/linux-nvme/nvme-cli/blob/v2.8/nvme-print-stdout.c#L2199-L2217
+	//
+	// This function uses go's binary notation + bitshifts instead of masking of hex numbers
+	// I think its easier to see whats going on this way vs hex masks
+	// Refresher:
+	//   1<<N makes gives us all zeros except for the Nth bit which is a one
+	//   fna & 1<<N is bitwise and, the result will be 1 if fna had a 1 in Nth bi
 
 	return []*common.Capability{
 		{
@@ -204,6 +210,12 @@ func parseSanicap(sanicap uint) ([]*common.Capability, error) {
 	// All names come from internal nvme-cli names
 	// We will *not* keep in sync as these names form our API
 	// https://github.com/linux-nvme/nvme-cli/blob/v2.8/nvme-print-stdout.c#L2064-L2093
+	//
+	// This function uses go's binary notation + bitshifts instead of masking of hex numbers
+	// I think its easier to see whats going on this way vs hex masks
+	// Refresher:
+	//   1<<N makes gives us all zeros except for the Nth bit which is a one
+	//   sanicap & 1<<N is bitwise and, the result will be 1 if sanicap had a 1 in Nth bit
 
 	caps := []*common.Capability{
 		{

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -190,17 +190,17 @@ func parseFna(fna uint) []*common.Capability {
 		{
 			Name:        "fmns",
 			Description: "Format Applies to All/Single Namespace(s) (t:All, f:Single)",
-			Enabled:     (fna&(0b1<<0))>>0 != 0,
+			Enabled:     fna&(0b1<<0) != 0,
 		},
 		{
 			Name:        "cens",
 			Description: "Crypto Erase Applies to All/Single Namespace(s) (t:All, f:Single)",
-			Enabled:     (fna&(0b1<<1))>>1 != 0,
+			Enabled:     fna&(0b1<<1) != 0,
 		},
 		{
 			Name:        "cese",
 			Description: "Crypto Erase Supported as part of Secure Erase",
-			Enabled:     (fna&(0b1<<2))>>2 != 0,
+			Enabled:     fna&(0b1<<2) != 0,
 		},
 	}
 }
@@ -221,26 +221,26 @@ func parseSanicap(sanicap uint) ([]*common.Capability, error) {
 		{
 			Name:        "cer",
 			Description: "Crypto Erase Sanitize Operation Supported",
-			Enabled:     (sanicap&(0b1<<0))>>0 != 0,
+			Enabled:     sanicap&(0b1<<0) != 0,
 		},
 		{
 			Name:        "ber",
 			Description: "Block Erase Sanitize Operation Supported",
-			Enabled:     (sanicap&(0b1<<1))>>1 != 0,
+			Enabled:     sanicap&(0b1<<1) != 0,
 		},
 		{
 			Name:        "owr",
 			Description: "Overwrite Sanitize Operation Supported",
-			Enabled:     (sanicap&(0b1<<2))>>2 != 0,
+			Enabled:     sanicap&(0b1<<2) != 0,
 		},
 		{
 			Name:        "ndi",
 			Description: "No-Deallocate After Sanitize bit in Sanitize command Supported",
-			Enabled:     (sanicap&(0b1<<29))>>29 != 0,
+			Enabled:     sanicap&(0b1<<29) != 0,
 		},
 	}
 
-	switch (sanicap & (0b11 << 30)) >> 30 {
+	switch sanicap & (0b11 << 30) >> 30 {
 	case 0b00:
 		// nvme prints this out for 0b00:
 		//   "Additional media modification after sanitize operation completes successfully is not defined"
@@ -250,7 +250,7 @@ func parseSanicap(sanicap uint) ([]*common.Capability, error) {
 		caps = append(caps, &common.Capability{
 			Name:        "nodmmas",
 			Description: "Media is additionally modified after sanitize operation completes successfully",
-			Enabled:     (sanicap&(0b11<<30))>>30 == 0b10,
+			Enabled:     sanicap&(0b11<<30)>>30 == 0b10,
 		})
 	case 0b11:
 		return nil, errSanicapNODMMASReserved

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -121,7 +121,7 @@ func (n *Nvme) list(ctx context.Context) ([]byte, error) {
 	// nvme list --output-format=json
 	n.Executor.SetArgs("list", "--output-format=json")
 
-	result, err := n.Executor.ExecWithContext(ctx)
+	result, err := n.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (n *Nvme) list(ctx context.Context) ([]byte, error) {
 func (n *Nvme) cmdListCapabilities(ctx context.Context, logicalPath string) ([]byte, error) {
 	// nvme id-ctrl --output-format=json devicepath
 	n.Executor.SetArgs("id-ctrl", "--output-format=json", logicalPath)
-	result, err := n.Executor.ExecWithContext(ctx)
+	result, err := n.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -119,7 +119,7 @@ func (n *Nvme) Drives(ctx context.Context) ([]*common.Drive, error) {
 
 func (n *Nvme) list(ctx context.Context) ([]byte, error) {
 	// nvme list --output-format=json
-	n.Executor.SetArgs([]string{"list", "--output-format=json"})
+	n.Executor.SetArgs("list", "--output-format=json")
 
 	result, err := n.Executor.ExecWithContext(ctx)
 	if err != nil {
@@ -131,7 +131,7 @@ func (n *Nvme) list(ctx context.Context) ([]byte, error) {
 
 func (n *Nvme) cmdListCapabilities(ctx context.Context, logicalPath string) ([]byte, error) {
 	// nvme id-ctrl --output-format=json devicepath
-	n.Executor.SetArgs([]string{"id-ctrl", "--output-format=json", logicalPath})
+	n.Executor.SetArgs("id-ctrl", "--output-format=json", logicalPath)
 	result, err := n.Executor.ExecWithContext(ctx)
 	if err != nil {
 		return nil, err

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -129,9 +129,9 @@ func (n *Nvme) list(ctx context.Context) ([]byte, error) {
 	return result.Stdout, nil
 }
 
-func (n *Nvme) cmdListCapabilities(ctx context.Context, logicalPath string) ([]byte, error) {
+func (n *Nvme) cmdListCapabilities(ctx context.Context, device string) ([]byte, error) {
 	// nvme id-ctrl --output-format=json devicepath
-	n.Executor.SetArgs("id-ctrl", "--output-format=json", logicalPath)
+	n.Executor.SetArgs("id-ctrl", "--output-format=json", device)
 	result, err := n.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
@@ -142,11 +142,11 @@ func (n *Nvme) cmdListCapabilities(ctx context.Context, logicalPath string) ([]b
 
 // DriveCapabilities returns the drive capability attributes obtained through nvme
 //
-// The logicalName is the kernel/OS assigned drive name - /dev/nvmeX
+// The device is the kernel/OS assigned drive name - /dev/nvmeX
 //
 // This method implements the actions.DriveCapabilityCollector interface.
-func (n *Nvme) DriveCapabilities(ctx context.Context, logicalName string) ([]*common.Capability, error) {
-	out, err := n.cmdListCapabilities(ctx, logicalName)
+func (n *Nvme) DriveCapabilities(ctx context.Context, device string) ([]*common.Capability, error) {
+	out, err := n.cmdListCapabilities(ctx, device)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -254,8 +254,6 @@ func parseSanicap(sanicap uint) ([]*common.Capability, error) {
 		})
 	case 0b11:
 		return nil, errSanicapNODMMASReserved
-	default:
-		panic("unreachable")
 	}
 
 	return caps, nil

--- a/utils/smartctl.go
+++ b/utils/smartctl.go
@@ -145,7 +145,7 @@ func (s *Smartctl) Drives(ctx context.Context) ([]*common.Drive, error) {
 func (s *Smartctl) Scan(ctx context.Context) (*SmartctlScan, error) {
 	s.Executor.SetArgs("--scan", "-j")
 
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (s *Smartctl) All(ctx context.Context, device string) (*SmartctlDriveAttrib
 	s.Executor.SetArgs("-a", device, "-j")
 
 	// smartctl can exit with a non-zero status based on drive smart data
-	result, _ := s.Executor.ExecWithContext(ctx)
+	result, _ := s.Executor.Exec(ctx)
 	// determine the errors if any based on the exit code
 	smartCtlErrs := smartCtlExitStatus(result.ExitCode)
 
@@ -279,8 +279,8 @@ func NewFakeSmartctl(dataDir string) *Smartctl {
 	return &Smartctl{Executor: executor}
 }
 
-// ExecWithContext implements the utils.Executor interface
-func (e *FakeSmartctlExecute) ExecWithContext(context.Context) (*Result, error) {
+// Exec implements the utils.Executor interface
+func (e *FakeSmartctlExecute) Exec(context.Context) (*Result, error) {
 	switch e.Args[0] {
 	case "--scan":
 		b, err := os.ReadFile(e.JSONFilesDir + "/scan.json")

--- a/utils/smartctl.go
+++ b/utils/smartctl.go
@@ -143,7 +143,7 @@ func (s *Smartctl) Drives(ctx context.Context) ([]*common.Drive, error) {
 
 // Scan runs smartctl scan -j and returns its value as an object
 func (s *Smartctl) Scan(ctx context.Context) (*SmartctlScan, error) {
-	s.Executor.SetArgs([]string{"--scan", "-j"})
+	s.Executor.SetArgs("--scan", "-j")
 
 	result, err := s.Executor.ExecWithContext(ctx)
 	if err != nil {
@@ -167,7 +167,7 @@ func (s *Smartctl) Scan(ctx context.Context) (*SmartctlScan, error) {
 // All runs smartctl -a /dev/<device> and returns its value as an object
 func (s *Smartctl) All(ctx context.Context, device string) (*SmartctlDriveAttributes, error) {
 	// smartctl -a /dev/sda1 -j
-	s.Executor.SetArgs([]string{"-a", device, "-j"})
+	s.Executor.SetArgs("-a", device, "-j")
 
 	// smartctl can exit with a non-zero status based on drive smart data
 	result, _ := s.Executor.ExecWithContext(ctx)
@@ -321,7 +321,7 @@ func (e *FakeSmartctlExecute) SetStdin(r io.Reader) {
 }
 
 // SetArgs is to set cmd args to the fake execute method
-func (e *FakeSmartctlExecute) SetArgs(a []string) {
+func (e *FakeSmartctlExecute) SetArgs(a ...string) {
 	e.Args = a
 }
 

--- a/utils/smc_ipmicfg.go
+++ b/utils/smc_ipmicfg.go
@@ -131,7 +131,7 @@ func (i *Ipmicfg) Summary(ctx context.Context) (*IpmicfgSummary, error) {
 	// smc-ipmicfg --summary
 	i.Executor.SetArgs("-summary")
 
-	result, err := i.Executor.ExecWithContext(ctx)
+	result, err := i.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/smc_ipmicfg.go
+++ b/utils/smc_ipmicfg.go
@@ -129,7 +129,7 @@ func (i Ipmicfg) CPLDs(ctx context.Context) ([]*common.CPLD, error) {
 
 func (i *Ipmicfg) Summary(ctx context.Context) (*IpmicfgSummary, error) {
 	// smc-ipmicfg --summary
-	i.Executor.SetArgs([]string{"-summary"})
+	i.Executor.SetArgs("-summary")
 
 	result, err := i.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/smc_ipmicfg_test.go
+++ b/utils/smc_ipmicfg_test.go
@@ -17,7 +17,7 @@ func initFakeIPMICfg() (*Ipmicfg, error) {
 	}
 
 	i := NewFakeIpmicfg(bytes.NewReader(b))
-	i.Executor.SetArgs([]string{"-summary"})
+	i.Executor.SetArgs("-summary")
 
 	return i, nil
 }

--- a/utils/smc_ipmicfg_test.go
+++ b/utils/smc_ipmicfg_test.go
@@ -78,7 +78,7 @@ func Test_IpmicfgParseSummaryOutput(t *testing.T) {
 		t.Error(err)
 	}
 
-	result, err := i.Executor.ExecWithContext(context.Background())
+	result, err := i.Executor.Exec(context.Background())
 	if err != nil {
 		t.Error(err)
 	}

--- a/utils/smc_sum.go
+++ b/utils/smc_sum.go
@@ -67,7 +67,7 @@ func (s *SupermicroSUM) UpdateBIOS(ctx context.Context, updateFile, modelNumber 
 		s.Executor.SetArgs("-c", "UpdateBios", "--file", updateFile)
 	}
 
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (s *SupermicroSUM) UpdateBIOS(ctx context.Context, updateFile, modelNumber 
 func (s *SupermicroSUM) UpdateBMC(ctx context.Context, updateFile, _ string) error {
 	s.Executor.SetArgs("-c", "UpdateBmc", "--file", updateFile)
 
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (s *SupermicroSUM) ApplyUpdate(ctx context.Context, updateFile, componentSl
 		s.Executor.SetArgs("-c", "UpdateBmc", "--file", updateFile)
 	}
 
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (s *SupermicroSUM) GetBIOSConfiguration(ctx context.Context, _ string) (map
 func (s *SupermicroSUM) parseBIOSConfig(ctx context.Context) (map[string]string, error) {
 	s.Executor.SetArgs("-c", "GetCurrentBiosCfg")
 
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -197,8 +197,8 @@ func NewFakeSMCSum(stdin io.Reader) *SupermicroSUM {
 	return &SupermicroSUM{Executor: executor}
 }
 
-// ExecWithContext implements the utils.Executor interface
-func (e *FakeSMCSumExecute) ExecWithContext(_ context.Context) (*Result, error) {
+// Exec implements the utils.Executor interface
+func (e *FakeSMCSumExecute) Exec(_ context.Context) (*Result, error) {
 	b := bytes.Buffer{}
 
 	if e.Stdin != nil {

--- a/utils/smc_sum.go
+++ b/utils/smc_sum.go
@@ -60,11 +60,11 @@ func (s *SupermicroSUM) Collect(_ *common.Device) error {
 
 // UpdateBIOS installs the SMC BIOS update
 func (s *SupermicroSUM) UpdateBIOS(ctx context.Context, updateFile, modelNumber string) error {
-	s.Executor.SetArgs([]string{"-c", "UpdateBios", "--preserve_setting", "--file", updateFile})
+	s.Executor.SetArgs("-c", "UpdateBios", "--preserve_setting", "--file", updateFile)
 
 	// X12STH-SYS does not support the preserve_setting option
 	if strings.EqualFold(modelNumber, "X12STH-SYS") {
-		s.Executor.SetArgs([]string{"-c", "UpdateBios", "--file", updateFile})
+		s.Executor.SetArgs("-c", "UpdateBios", "--file", updateFile)
 	}
 
 	result, err := s.Executor.ExecWithContext(ctx)
@@ -81,7 +81,7 @@ func (s *SupermicroSUM) UpdateBIOS(ctx context.Context, updateFile, modelNumber 
 
 // UpdateBMC installs the SMC BMC update
 func (s *SupermicroSUM) UpdateBMC(ctx context.Context, updateFile, _ string) error {
-	s.Executor.SetArgs([]string{"-c", "UpdateBmc", "--file", updateFile})
+	s.Executor.SetArgs("-c", "UpdateBmc", "--file", updateFile)
 
 	result, err := s.Executor.ExecWithContext(ctx)
 	if err != nil {
@@ -99,9 +99,9 @@ func (s *SupermicroSUM) UpdateBMC(ctx context.Context, updateFile, _ string) err
 func (s *SupermicroSUM) ApplyUpdate(ctx context.Context, updateFile, componentSlug string) error {
 	switch componentSlug {
 	case common.SlugBIOS:
-		s.Executor.SetArgs([]string{"-c", "UpdateBios", "--preserve_setting", "--file", updateFile})
+		s.Executor.SetArgs("-c", "UpdateBios", "--preserve_setting", "--file", updateFile)
 	case common.SlugBMC:
-		s.Executor.SetArgs([]string{"-c", "UpdateBmc", "--file", updateFile})
+		s.Executor.SetArgs("-c", "UpdateBmc", "--file", updateFile)
 	}
 
 	result, err := s.Executor.ExecWithContext(ctx)
@@ -123,7 +123,7 @@ func (s *SupermicroSUM) GetBIOSConfiguration(ctx context.Context, _ string) (map
 
 // parseBIOSConfig parses the SMC sum command output BIOS config and returns a model.BIOSConfiguration object
 func (s *SupermicroSUM) parseBIOSConfig(ctx context.Context) (map[string]string, error) {
-	s.Executor.SetArgs([]string{"-c", "GetCurrentBiosCfg"})
+	s.Executor.SetArgs("-c", "GetCurrentBiosCfg")
 
 	result, err := s.Executor.ExecWithContext(ctx)
 	if err != nil {
@@ -217,7 +217,7 @@ func (e *FakeSMCSumExecute) SetStdin(r io.Reader) {
 }
 
 // SetArgs is to set cmd args to the fake execute method
-func (e *FakeSMCSumExecute) SetArgs(a []string) {
+func (e *FakeSMCSumExecute) SetArgs(a ...string) {
 	e.Args = a
 }
 

--- a/utils/storecli.go
+++ b/utils/storecli.go
@@ -130,7 +130,7 @@ func (s *StoreCLI) ShowController0(ctx context.Context) ([]byte, error) {
 	// /opt/MegaRAID/storcli/storcli64 /c0 show J
 	s.Executor.SetArgs("/c0", "show", "J")
 
-	result, err := s.Executor.ExecWithContext(ctx)
+	result, err := s.Executor.Exec(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/storecli.go
+++ b/utils/storecli.go
@@ -128,7 +128,7 @@ func (s *StoreCLI) StorageControllers(ctx context.Context) ([]*common.StorageCon
 // ShowController0 runs storecli to list controller 0
 func (s *StoreCLI) ShowController0(ctx context.Context) ([]byte, error) {
 	// /opt/MegaRAID/storcli/storcli64 /c0 show J
-	s.Executor.SetArgs([]string{"/c0", "show", "J"})
+	s.Executor.SetArgs("/c0", "show", "J")
 
 	result, err := s.Executor.ExecWithContext(ctx)
 	if err != nil {

--- a/utils/uefi_firmware_parser.go
+++ b/utils/uefi_firmware_parser.go
@@ -55,14 +55,7 @@ func (u *UefiFirmwareParser) ExtractLogo(ctx context.Context, outputPath, biosIm
 		return err
 	}
 
-	u.Executor.SetArgs([]string{
-		"-b",
-		biosImg,
-		"-o",
-		outputPath,
-		"-e",
-	})
-
+	u.Executor.SetArgs("-b", biosImg, "-o", outputPath, "-e")
 	_, err := u.Executor.ExecWithContext(ctx)
 	return err
 }

--- a/utils/uefi_firmware_parser.go
+++ b/utils/uefi_firmware_parser.go
@@ -56,6 +56,6 @@ func (u *UefiFirmwareParser) ExtractLogo(ctx context.Context, outputPath, biosIm
 	}
 
 	u.Executor.SetArgs("-b", biosImg, "-o", outputPath, "-e")
-	_, err := u.Executor.ExecWithContext(ctx)
+	_, err := u.Executor.Exec(ctx)
 	return err
 }

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -77,8 +77,8 @@ func writeWatermarks(file *os.File, watermarksCount, watermarksSize int64) ([]wa
 		return nil, err
 	}
 
-	if fileSize == 0 {
-		return nil, errors.New("no space for watermarking")
+	if fileSize <= watermarksCount*watermarksSize {
+		return nil, fmt.Errorf("no space for watermarking: %w", io.ErrUnexpectedEOF)
 	}
 	chunkSize := fileSize / watermarksCount
 

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -16,6 +16,8 @@ const (
 	numWatermarks = 10
 )
 
+var ErrIneffectiveWipe = errors.New("found left over data after wiping disk")
+
 type watermark struct {
 	position int64
 	data     []byte
@@ -68,8 +70,7 @@ func ApplyWatermarks(logicalName string) (func() error, error) {
 			}
 			// Check if the watermark is still in the disk
 			if slices.Equal(currentValue, watermark.data) {
-				ErrorExistingWatermark := errors.New("Error existing watermark in the position: ")
-				return fmt.Errorf("%s@%d | %w", logicalName, watermark.position, ErrorExistingWatermark)
+				return fmt.Errorf("verify wipe %s@%d: %w", logicalName, watermark.position, ErrIneffectiveWipe)
 			}
 		}
 		return nil

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -90,12 +90,12 @@ func writeWatermarks(file *os.File, watermarksCount, watermarksSize int64) ([]wa
 			return nil, err
 		}
 
-		offset, err := rand.Int(rand.Reader, big.NewInt(chunkSize))
+		offset, err := rand.Int(rand.Reader, big.NewInt(chunkSize-watermarksSize))
 		if err != nil {
 			return nil, err
 		}
 
-		randomPosition := chunkStart + offset.Int64() - watermarksSize
+		randomPosition := chunkStart + offset.Int64()
 		_, err = file.Seek(randomPosition, io.SeekStart)
 		if err != nil {
 			return nil, err

--- a/utils/watermark_disk_test.go
+++ b/utils/watermark_disk_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/rand"
+	"io"
 	"os"
 	"testing"
 
@@ -28,7 +29,7 @@ func Test_ApplyWatermarks(t *testing.T) {
 
 		checker, err := ApplyWatermarks(tempFile)
 		assert.Nil(t, checker)
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
 
 	t.Run("EmptyFile", func(t *testing.T) {
@@ -36,7 +37,7 @@ func Test_ApplyWatermarks(t *testing.T) {
 
 		checker, err := ApplyWatermarks(tempFile)
 		assert.Nil(t, checker)
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
 
 	t.Run("WipeSucceeded", func(t *testing.T) {
@@ -72,6 +73,6 @@ func Test_ApplyWatermarks(t *testing.T) {
 		checker, err := ApplyWatermarks(tempFile)
 		assert.NoError(t, err)
 
-		assert.Error(t, checker())
+		assert.ErrorIs(t, checker(), ErrIneffectiveWipe)
 	})
 }


### PR DESCRIPTION
I've split these commits out from #136 where they came up. The commits here are grouped into fixes and qol stuff. The QoL stuff are changes to Executor and some missed code comments/fixes to nvme that were meant to go in during #129.

The other big chunk of changes is to utils/watermark where I ran into incorrect params to rand.Int that would cause us to seek to a negative position. I fixed that and added some documentation and renamed some variables for clarity. Also tweaked the tests a little and added a new test case.