### PR TITLE
Add basic support for blkdiscard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Ironlib identifies the hardware and executes tooling respective to the hardware/
 
 The list of tools that ironlib wraps around, in no particular order,
 
+- blkdiscard
 - dell racadm
 - dmidecode
 - dell dsu
@@ -93,6 +94,7 @@ IRONLIB_UTIL_ASRR_BIOSCONTROL
 IRONLIB_UTIL_RACADM7
 IRONLIB_UTIL_DNF
 IRONLIB_UTIL_DSU
+IRONLIB_UTIL_BLKDISCARD
 IRONLIB_UTIL_HDPARM
 IRONLIB_UTIL_LSBLK
 IRONLIB_UTIL_LSHW

--- a/examples/blkdiscard/main.go
+++ b/examples/blkdiscard/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/metal-toolbox/ironlib/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	device  = "/dev/sdZZZ"
+	timeout = 2 * time.Minute
+)
+
+// This example invokes ironlib and runs blkdiscard on the disk /dev/sdZZZ
+func main() {
+	logger := logrus.New()
+	logger.Formatter = new(logrus.JSONFormatter)
+	logger.SetLevel(logrus.TraceLevel)
+
+	blkdiscard := utils.NewBlkdiscardCmd()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	logger.Info("running blkdiscard on", device)
+	err := blkdiscard.Discard(ctx, device)
+	if err != nil {
+		logger.WithError(err).Fatal("exiting")
+	}
+}

--- a/utils/blkdiscard.go
+++ b/utils/blkdiscard.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"context"
+	"os"
+)
+
+const (
+	EnvBlkdiscardUtility = "IRONLIB_UTIL_BLKDISCARD"
+)
+
+type Blkdiscard struct {
+	Executor Executor
+}
+
+// Return a new blkdiscard executor
+func NewBlkdiscardCmd() *Blkdiscard {
+	utility := "blkdiscard"
+
+	// lookup env var for util
+	if eVar := os.Getenv(EnvBlkdiscardUtility); eVar != "" {
+		utility = eVar
+	}
+
+	e := NewExecutor(utility)
+	e.SetEnv([]string{"LC_ALL=C.UTF-8"})
+
+	return &Blkdiscard{Executor: e}
+}
+
+// Discard runs blkdiscard on the given device (--force is always used)
+func (b *Blkdiscard) Discard(ctx context.Context, device string) error {
+	b.Executor.SetArgs("--force", device)
+
+	_, err := b.Executor.Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewFakeBlkdiscard returns a mock implementation of the Blkdiscard interface for use in tests.
+func NewFakeBlkdiscard() *Blkdiscard {
+	return &Blkdiscard{
+		Executor: NewFakeExecutor("blkdiscard"),
+	}
+}

--- a/utils/blkdiscard_test.go
+++ b/utils/blkdiscard_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_blkdiscard(t *testing.T) {
+	err := NewFakeBlkdiscard().Discard(context.TODO(), "/dev/sdZZZ")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
blkdiscard is a pretty basic command, it simply gets run against a block device, and returns an exit code. We always want to include the --force flag.

### What does this PR do

### The HW vendor this change applies to (if applicable)

### The HW model number, product name this change applies to (if applicable)

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

### How can this change be tested by a PR reviewer?

### Description for changelog/release notes
