### PR TITLE
Add basic support for blkdiscard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Ironlib identifies the hardware and executes tooling respective to the hardware/
 
 The list of tools that ironlib wraps around, in no particular order,
 
+- blkdiscard
 - dell racadm
 - dmidecode
 - dell dsu
@@ -93,6 +94,7 @@ IRONLIB_UTIL_ASRR_BIOSCONTROL
 IRONLIB_UTIL_RACADM7
 IRONLIB_UTIL_DNF
 IRONLIB_UTIL_DSU
+IRONLIB_UTIL_BLKDISCARD
 IRONLIB_UTIL_HDPARM
 IRONLIB_UTIL_LSBLK
 IRONLIB_UTIL_LSHW

--- a/examples/blkdiscard/main.go
+++ b/examples/blkdiscard/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/metal-toolbox/ironlib/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	device  = flag.String("device", "/dev/sdZZZ", "disk to wipe using blkdiscard")
+	timeout = flag.String("timeout", (2 * time.Minute).String(), "time to wait for command to complete")
+)
+
+// This example invokes ironlib and runs blkdiscard on the disk /dev/sdZZZ
+func main() {
+	flag.Parse()
+
+	logger := logrus.New()
+	logger.Formatter = new(logrus.TextFormatter)
+	logger.SetLevel(logrus.TraceLevel)
+
+	timeout, err := time.ParseDuration(*timeout)
+	if err != nil {
+		logger.WithError(err).Fatal("failed to parse timeout duration")
+	}
+
+	blkdiscard := utils.NewBlkdiscardCmd()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	logger.Info("running blkdiscard on ", *device)
+	err = blkdiscard.Discard(ctx, *device)
+	if err != nil {
+		logger.WithError(err).Fatal("exiting")
+	}
+}

--- a/utils/blkdiscard.go
+++ b/utils/blkdiscard.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"cmp"
+	"context"
+	"os"
+)
+
+const (
+	EnvBlkdiscardUtility = "IRONLIB_UTIL_BLKDISCARD"
+)
+
+type Blkdiscard struct {
+	Executor Executor
+}
+
+// Return a new blkdiscard executor
+func NewBlkdiscardCmd() *Blkdiscard {
+	// lookup env var for util
+	utility := cmp.Or(os.Getenv(EnvBlkdiscardUtility), "blkdiscard")
+
+	e := NewExecutor(utility)
+	e.SetEnv([]string{"LC_ALL=C.UTF-8"})
+
+	return &Blkdiscard{Executor: e}
+}
+
+// Discard runs blkdiscard on the given device (--force is always used)
+func (b *Blkdiscard) Discard(ctx context.Context, device string) error {
+	b.Executor.SetArgs("--force", device)
+
+	_, err := b.Executor.Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewFakeBlkdiscard returns a mock implementation of the Blkdiscard interface for use in tests.
+func NewFakeBlkdiscard() *Blkdiscard {
+	return &Blkdiscard{
+		Executor: NewFakeExecutor("blkdiscard"),
+	}
+}

--- a/utils/blkdiscard_test.go
+++ b/utils/blkdiscard_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_blkdiscard(t *testing.T) {
+	err := NewFakeBlkdiscard().Discard(context.TODO(), "/dev/sdZZZ")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
blkdiscard is a pretty basic command, it simply gets run against a block device, and returns an exit code. We always include the --force flag.

### How has this been tested?

On an Equinix Metal server with several spare disks, I've modified the `examples/blkdiscard/main.go` to point to one of these disks and confirmed that:

* The command succeeds in the happy path, and wipes the disk device which I had previously created a filesystem on
* The command is correctly using the --force flag, and will discard blocks even on a mounted disk device
* The command fails when it tries to run against a non-existent disk device
* The command fails when I set the context timeout to too low of a value (e.g, 1 second) 

### Description for changelog/release notes

Add support for blkdiscard command
