### PR TITLE
Silence unnecessary warning in CollectFirmwareChecksums

### DIFF
--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -704,7 +704,6 @@ func (a *InventoryCollectorAction) CollectFirmwareChecksums(ctx context.Context)
 
 	sumStr, err := a.collectors.FirmwareChecksumCollector.BIOSLogoChecksum(ctx)
 	if err != nil {
-		a.log.WithError(err).Warn("error collecting BIOS Logo checksum")
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do

Quiets down "error collectiong BIOS Logo checksum" error messages during inventory action.

### The HW vendor this change applies to (if applicable)

Any where flashrom errors while trying to get the logo checksums, for example:

```
reading firmware binary image: cmd flashrom -p internal --ifd -i bios -r /tmp/bios_checksum/bios_img.bin exited with error: FCH device found but SMBus revision 0x61 does not match known values.
Please report this to flashrom@flashrom.org and include this log and
the output of lspci -nnvx, thanks!.
Could not determine chipset generation.
	exitCode: 1
	stdout: flashrom v1.3.0 on Linux 6.8.7 (x86_64)
flashrom is free software, get the source code at https://flashrom.org

Using clock_gettime for delay loops (clk_id: 1, resolution: 1ns).
Found chipset "AMD FP4".
Enabling flash write... PROBLEMS, continuing anyway
No EEPROM/flash device found.
Note: flashrom can never write if the flash chip isn't found automatically.
```

### How can this change be tested by a PR reviewer?

Run it on a machine w/o a bios that flashrom can interrogate and see no errors logged.