### PR TITLE
Add support for hdparm based drive wipe

### DIFF
--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -223,13 +223,13 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 	)
 	for _, cap := range drive.Capabilities {
 		switch {
-		case cap.Name == "esee":
+		case cap.Description == "encryption supports enhanced erase":
 			esee = cap.Enabled
-		case cap.Name == "bee":
+		case cap.Description == "BLOCK ERASE EXT":
 			bee = cap.Enabled
-		case cap.Name == "cse":
+		case cap.Description == "CRYPTO SCRAMBLE EXT":
 			cse = cap.Enabled
-		case cap.Name == "sf":
+		case cap.Description == "SANITIZE feature":
 			sanitize = cap.Enabled
 		case strings.HasPrefix(cap.Description, "erase time:"):
 			eseu = strings.Contains(cap.Description, "enhanced")

--- a/utils/hdparm_test.go
+++ b/utils/hdparm_test.go
@@ -293,3 +293,61 @@ var fixtureHdparmDeviceCapabilities = []*common.Capability{
 		Enabled:     false,
 	},
 }
+
+func Test_HdparmSanitizeDone(t *testing.T) {
+	// note the order is not messed up, this is indeed what hdparm showed me
+	tests := []struct {
+		name string
+		done bool
+		in   string
+	}{
+		{
+			name: "5%",
+			in: `
+/dev/sdb:
+Issuing SANITIZE_STATUS command
+Sanitize status:
+    State:    SD2 Sanitize operation In Process
+    Progress: 0xf5a (5%)
+`,
+		},
+		{
+			name: "1%",
+			in: `
+/dev/sdb:
+Issuing SANITIZE_STATUS command
+Sanitize status:
+    State:    SD2 Sanitize operation In Process
+    Progress: 0x28f (1%)
+`,
+		},
+		{
+			name: "3%",
+			in: `
+/dev/sdb:
+Issuing SANITIZE_STATUS command
+Sanitize status:
+    State:    SD2 Sanitize operation In Process
+    Progress: 0xa3c (3%)
+`,
+		},
+		{
+			name: "done",
+			done: true,
+			in: `
+/dev/sdb:
+Issuing SANITIZE_STATUS command
+Sanitize status:
+    State:    SD0 Sanitize Idle
+    Last Sanitize Operation Completed Without Error
+`,
+		},
+	}
+
+	var h Hdparm
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.done, h.sanitizeDone([]byte(test.in)))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do

Similar to what we're doing for NVME devices, this command supports
Sanitizing and Erasing and decides which function and parameters to use
depending on the capabilities reported by the drive.

Sanitize is preferred over erase. Cryptographic scramble is preferred of
block erase within Sanitize.

I reused the nvme sanitize/erase type since utils is all one big package
anyway to avoid confusion. If we ever split each utility into its own
package (as I want) then we'll just create a more specific type for
hdparm.