### PR TITLE
Change Info log messages

### DIFF
--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -689,7 +689,7 @@ func (a *InventoryCollectorAction) CollectFirmwareChecksums(ctx context.Context)
 	}()
 
 	if a.collectors.FirmwareChecksumCollector == nil {
-		a.log.Info("nil firmware checksum collector")
+		a.log.Debug("nil firmware checksum collector")
 		return nil
 	}
 
@@ -698,7 +698,7 @@ func (a *InventoryCollectorAction) CollectFirmwareChecksums(ctx context.Context)
 	if slices.Contains(a.disabledCollectorUtilities, collectorKind) ||
 		slices.Contains(a.disabledCollectorUtilities, firmware.FirmwareDumpUtility) ||
 		slices.Contains(a.disabledCollectorUtilities, firmware.UEFIParserUtility) {
-		a.log.Info("firmware checksum disabled")
+		a.log.Debug("firmware checksum disabled")
 		return nil
 	}
 

--- a/examples/diskwipe/main.go
+++ b/examples/diskwipe/main.go
@@ -95,7 +95,7 @@ func main() {
 			// If the user supplied a non-default timeout then we'll honor it, otherwise we just go with a huge timeout.
 			// If this were *real* code and not an example some work could be done to guesstimate a timeout based on disk size.
 			if timeout == defaultTimeout {
-				l.WithField("timeout", timeout.String()).Info("increasing timeout")
+				l.WithField("timeout", timeout.String()).Debug("increasing timeout")
 				timeout = 24 * time.Hour
 				ctx, cancel = context.WithTimeout(context.WithoutCancel(ctx), timeout)
 				defer cancel()

--- a/examples/diskwipe/main.go
+++ b/examples/diskwipe/main.go
@@ -107,7 +107,9 @@ func main() {
 		l.Fatal("failed find appropriate wiper drive")
 	}
 
-	err = wiper.WipeDrive(ctx, logger, drive)
+	ll := logger
+	ll.SetLevel(logrus.DebugLevel)
+	err = wiper.WipeDrive(ctx, ll, drive)
 	if err != nil {
 		l.Fatal("failed to wipe drive")
 	}

--- a/examples/nvme-ns-wipe/main.go
+++ b/examples/nvme-ns-wipe/main.go
@@ -34,7 +34,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	logger.Info("resetting namespaces")
+	logger.Debug("resetting namespaces")
 	err = nvme.ResetNS(ctx, *logicalName)
 	if err != nil {
 		logger.WithError(err).Fatal("exiting")

--- a/providers/asrockrack/asrockrack.go
+++ b/providers/asrockrack/asrockrack.go
@@ -52,7 +52,7 @@ func New(dmidecode *utils.Dmidecode, l *logrus.Logger) (actions.DeviceManager, e
 // Returns hardware inventory for the device
 func (a *asrockrack) GetInventory(ctx context.Context, options ...actions.Option) (*common.Device, error) {
 	// Collect device inventory
-	a.logger.Info("Collecting inventory")
+	a.logger.Debug("Collecting inventory")
 
 	deviceObj := common.NewDevice()
 	a.hw.Device = &deviceObj

--- a/providers/dell/dell.go
+++ b/providers/dell/dell.go
@@ -114,7 +114,7 @@ func (d *dell) UpdatesApplied() bool {
 // GetInventory collects hardware inventory along with the firmware installed and returns a Device object
 func (d *dell) GetInventory(ctx context.Context, options ...actions.Option) (*common.Device, error) {
 	// Collect device inventory
-	d.logger.Info("Collecting hardware inventory")
+	d.logger.Debug("Collecting hardware inventory")
 
 	collector := actions.NewInventoryCollectorAction(d.logger, options...)
 	if err := collector.Collect(ctx, d.hw.Device); err != nil {
@@ -142,7 +142,7 @@ func (d *dell) GetInventoryOEM(ctx context.Context, _ *common.Device, options *m
 // ListAvailableUpdates runs the vendor tooling (dsu) to identify updates available
 func (d *dell) ListAvailableUpdates(ctx context.Context, options *model.UpdateOptions) (*common.Device, error) {
 	// collect firmware updates available for components
-	d.logger.Info("Identifying component firmware updates...")
+	d.logger.Debug("Identifying component firmware updates...")
 
 	d.setUpdateOptions(options)
 
@@ -153,11 +153,11 @@ func (d *dell) ListAvailableUpdates(ctx context.Context, options *model.UpdateOp
 
 	count := len(oemUpdates)
 	if count == 0 {
-		d.logger.Info("no available dell Oem updates")
+		d.logger.Debug("no available dell Oem updates")
 		return nil, nil
 	}
 
-	d.logger.WithField("count", count).Info("component updates identified..")
+	d.logger.WithField("count", count).Debug("component updates identified..")
 
 	d.hw.OEMComponents = append(d.hw.OEMComponents, oemUpdates...)
 
@@ -225,7 +225,7 @@ func (d *dell) setUpdateOptions(options *model.UpdateOptions) {
 			"dsu repo":    d.dsuReleaseVersion,
 			"base url":    d.updateBaseURL,
 		},
-	).Info("update parameters")
+	).Debug("update parameters")
 }
 
 // ApplyUpdate is here to satisfy the actions.Updater interface

--- a/providers/dell/helpers.go
+++ b/providers/dell/helpers.go
@@ -79,7 +79,7 @@ func (d *dell) installUpdate(ctx context.Context, updateFile string, downgrade b
 
 	d.logger.WithFields(
 		logrus.Fields{"file": updateFile},
-	).Info("Installing dell Update Bin file")
+	).Debug("Installing dell Update Bin file")
 
 	result, err := e.Exec(ctx)
 	if err != nil {
@@ -88,7 +88,7 @@ func (d *dell) installUpdate(ctx context.Context, updateFile string, downgrade b
 
 	d.logger.WithFields(
 		logrus.Fields{"file": updateFile},
-	).Info("Installed")
+	).Debug("Installed")
 
 	d.hw.PendingReboot = true
 
@@ -140,7 +140,7 @@ func (d *dell) pre(ctx context.Context) (err error) {
 		}
 	}
 
-	d.logger.Info("Dell DSU prerequisites setup complete")
+	d.logger.Debug("Dell DSU prerequisites setup complete")
 	d.DsuPrequisitesInstalled = true
 
 	return nil

--- a/providers/generic/generic.go
+++ b/providers/generic/generic.go
@@ -53,7 +53,7 @@ func New(dmidecode *utils.Dmidecode, l *logrus.Logger) (actions.DeviceManager, e
 // Returns hardware inventory for the device
 func (a *Generic) GetInventory(ctx context.Context, options ...actions.Option) (*common.Device, error) {
 	// Collect device inventory
-	a.logger.Info("Collecting inventory")
+	a.logger.Debug("Collecting inventory")
 
 	collector := actions.NewInventoryCollectorAction(a.logger, options...)
 	if err := collector.Collect(ctx, a.hw.Device); err != nil {

--- a/providers/supermicro/supermicro.go
+++ b/providers/supermicro/supermicro.go
@@ -70,7 +70,7 @@ func (s *supermicro) UpdatesApplied() bool {
 // GetInventory collects hardware inventory along with the firmware installed and returns a Device object
 func (s *supermicro) GetInventory(ctx context.Context, options ...actions.Option) (*common.Device, error) {
 	// Collect device inventory
-	s.logger.Info("Collecting hardware inventory")
+	s.logger.Debug("Collecting hardware inventory")
 
 	// define collectors for supermicro hardware
 	collectors := &actions.Collectors{

--- a/utils/blkdiscard.go
+++ b/utils/blkdiscard.go
@@ -51,7 +51,7 @@ func (b *Blkdiscard) Discard(ctx context.Context, drive *common.Drive) error {
 
 // WipeDrive implements DriveWipe by calling Discard
 func (b *Blkdiscard) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *common.Drive) error {
-	logger.WithField("drive", drive.LogicalName).WithField("method", "blkdiscard").Info("wiping")
+	logger.WithField("drive", drive.LogicalName).WithField("method", "blkdiscard").Debug("wiping")
 	return b.Discard(ctx, drive)
 }
 

--- a/utils/fill_zero.go
+++ b/utils/fill_zero.go
@@ -26,7 +26,7 @@ func NewFillZeroCmd(trace bool) *FillZero {
 
 func (z *FillZero) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *common.Drive) error {
 	log := logger.WithField("drive", drive.LogicalName).WithField("method", "zero-fill")
-	log.Info("wiping")
+	log.Debug("wiping")
 
 	verify, err := ApplyWatermarks(drive)
 	if err != nil {
@@ -46,7 +46,7 @@ func (z *FillZero) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *
 		return err
 	}
 
-	log.WithField("size", fmt.Sprintf("%dB", partitionSize)).Info("disk info detected")
+	log.WithField("size", fmt.Sprintf("%dB", partitionSize)).Debug("disk info detected")
 	_, err = file.Seek(0, io.SeekStart)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (z *FillZero) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *
 		// Check if the context has been canceled
 		select {
 		case <-ctx.Done():
-			log.Info("stopping")
+			log.Debug("stopping")
 			return ctx.Err()
 		default:
 			l := min(int64(len(buffer)), bytesRemaining)
@@ -100,7 +100,7 @@ func printProgress(log *logrus.Entry, totalBytesWritten, partitionSize int64, st
 		"progress":  fmt.Sprintf("%.2f%%", progress),
 		"speed":     fmt.Sprintf("%.2f MB/s", mbPerSecond),
 		"remaining": fmt.Sprintf("%.2f hour(s)", remainingHours),
-	}).Info("")
+	}).Debug("")
 }
 
 // SetQuiet lowers the verbosity

--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -240,7 +240,7 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 	if sanitize && cse {
 		// nolint:govet
 		l := l.WithField("method", "sanitize").WithField("action", "sanitize-crypto-scramble")
-		l.Info("wiping")
+		l.Debug("wiping")
 		err := h.Sanitize(ctx, drive, CryptoErase)
 		if err == nil {
 			return nil
@@ -250,7 +250,7 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 	if sanitize && bee {
 		// nolint:govet
 		l := l.WithField("method", "sanitize").WithField("action", "sanitize-block-erase")
-		l.Info("wiping")
+		l.Debug("wiping")
 		err := h.Sanitize(ctx, drive, BlockErase)
 		if err == nil {
 			return nil
@@ -260,7 +260,7 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 	if esee && eseu {
 		// nolint:govet
 		l := l.WithField("method", "security-erase-enhanced")
-		l.Info("wiping")
+		l.Debug("wiping")
 		err := h.Erase(ctx, drive, CryptographicErase)
 		if err == nil {
 			return nil

--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -245,7 +245,7 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 		if err == nil {
 			return nil
 		}
-		l.WithError(err).Info("failed")
+		l.WithError(err).Error("failed")
 	}
 	if sanitize && bee {
 		// nolint:govet
@@ -255,7 +255,7 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 		if err == nil {
 			return nil
 		}
-		l.WithError(err).Info("failed")
+		l.WithError(err).Error("failed")
 	}
 	if esee && eseu {
 		// nolint:govet
@@ -265,7 +265,7 @@ func (h *Hdparm) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *co
 		if err == nil {
 			return nil
 		}
-		l.WithError(err).Info("failed")
+		l.WithError(err).Error("failed")
 	}
 	return ErrIneffectiveWipe
 }

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -310,7 +310,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 	if cer {
 		// nolint:govet
 		l := l.WithField("method", "sanitize").WithField("action", CryptoErase)
-		l.Info("wiping")
+		l.Debug("wiping")
 		err := n.Sanitize(ctx, drive, CryptoErase)
 		if err == nil {
 			return nil
@@ -320,7 +320,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 	if ber {
 		// nolint:govet
 		l := l.WithField("method", "sanitize").WithField("action", BlockErase)
-		l.Info("wiping")
+		l.Debug("wiping")
 		err := n.Sanitize(ctx, drive, BlockErase)
 		if err == nil {
 			return nil
@@ -330,7 +330,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 	if cese {
 		// nolint:govet
 		l := l.WithField("method", "format").WithField("setting", CryptographicErase)
-		l.Info("wiping")
+		l.Debug("wiping")
 		err := n.Format(ctx, drive, CryptographicErase)
 		if err == nil {
 			return nil
@@ -339,7 +339,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 	}
 
 	l = l.WithField("method", "format").WithField("setting", UserDataErase)
-	l.Info("wiping")
+	l.Debug("wiping")
 	err := n.Format(ctx, drive, UserDataErase)
 	if err == nil {
 		return nil

--- a/utils/nvme.go
+++ b/utils/nvme.go
@@ -315,7 +315,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 		if err == nil {
 			return nil
 		}
-		l.WithError(err).Info("failed")
+		l.WithError(err).Error("failed")
 	}
 	if ber {
 		// nolint:govet
@@ -325,7 +325,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 		if err == nil {
 			return nil
 		}
-		l.WithError(err).Info("failed")
+		l.WithError(err).Error("failed")
 	}
 	if cese {
 		// nolint:govet
@@ -335,7 +335,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 		if err == nil {
 			return nil
 		}
-		l.WithError(err).Info("failed")
+		l.WithError(err).Error("failed")
 	}
 
 	l = l.WithField("method", "format").WithField("setting", UserDataErase)
@@ -344,7 +344,7 @@ func (n *Nvme) WipeDrive(ctx context.Context, logger *logrus.Logger, drive *comm
 	if err == nil {
 		return nil
 	}
-	l.WithError(err).Info("failed")
+	l.WithError(err).Error("failed")
 	return ErrIneffectiveWipe
 }
 


### PR DESCRIPTION
### What does this PR do

Changes messages that are logged as `.Info` to either `.Debug` or `.Error` as appropriate. We should not be logging under `.Info` in a library.
