### PR TITLE
Update requirements getter

### DIFF
--- a/actions/interface.go
+++ b/actions/interface.go
@@ -149,6 +149,12 @@ type UEFIVarsCollector interface {
 
 // Updaters
 
+// UpdateRequirements returns requirements to be met before and after a firmware install,
+// the caller may use the information to determine if a powercycle, reconfiguration or other actions are required on the component.
+type UpdateRequirementsGetter interface {
+	UpdateRequirements(componentModel string) model.UpdateRequirements
+}
+
 // DriveUpdater defines an interface to update drive firmware
 type DriveUpdater interface {
 	UtilAttributeGetter
@@ -158,8 +164,8 @@ type DriveUpdater interface {
 // NICUpdater defines an interface to update NIC firmware
 type NICUpdater interface {
 	UtilAttributeGetter
+	UpdateRequirementsGetter
 	UpdateNIC(ctx context.Context, updateFile, modelNumber string, force bool) error
-	UpdateRequirements() model.UpdateRequirements
 }
 
 // BMCUpdater defines an interface to update BMC firmware

--- a/actions/interface.go
+++ b/actions/interface.go
@@ -45,6 +45,8 @@ type Getter interface {
 	ListAvailableUpdates(ctx context.Context, options *model.UpdateOptions) (*common.Device, error)
 	// Retrieve BIOS configuration for device
 	GetBIOSConfiguration(ctx context.Context) (map[string]string, error)
+	// UpdateRequirements returns requirements to be met before and after a firmware install
+	UpdateRequirements(ctx context.Context, componentSlug, componentVendor, componentModel string) (model.UpdateRequirements, error)
 }
 
 // Utility interface couples the configuration, collection and update interfaces

--- a/errs/errors.go
+++ b/errs/errors.go
@@ -6,15 +6,18 @@ import (
 )
 
 var (
-	ErrNoUpdatesApplicable         = errors.New("no updates applicable")
-	ErrDmiDecodeRun                = errors.New("error running dmidecode")
-	ErrComponentListExpected       = errors.New("expected a list of components to apply updates")
-	ErrDeviceInventory             = errors.New("failed to collect device inventory")
-	ErrUnsupportedDiskVendor       = errors.New("unsupported disk vendor")
-	ErrNoUpdateHandlerForComponent = errors.New("component slug has no update handler declared")
-	ErrBinNotExecutable            = errors.New("bin has no executable bit set")
-	ErrBinLstat                    = errors.New("failed to run lstat on bin")
-	ErrBinLookupPath               = errors.New("failed to lookup bin path")
+	ErrNoUpdatesApplicable            = errors.New("no updates applicable")
+	ErrDmiDecodeRun                   = errors.New("error running dmidecode")
+	ErrComponentListExpected          = errors.New("expected a list of components to apply updates")
+	ErrDeviceInventory                = errors.New("failed to collect device inventory")
+	ErrUnsupportedDiskVendor          = errors.New("unsupported disk vendor")
+	ErrNoUpdateHandlerForComponent    = errors.New("component slug has no update handler declared")
+	ErrNoUpdateReqHandlerForComponent = errors.New("component slug has no update requirements handler declared")
+	ErrNoUpdateReqGetterForComponent  = errors.New("component slug has no update requirements getter handler declared")
+	ErrBinNotExecutable               = errors.New("bin has no executable bit set")
+	ErrBinLstat                       = errors.New("failed to run lstat on bin")
+	ErrBinLookupPath                  = errors.New("failed to lookup bin path")
+	ErrUpdateReqNotImplemented        = errors.New("UpdateRequirementsGetter interface not implemented")
 )
 
 // DmiDecodeValueError is returned when a dmidecode value could not be retrieved

--- a/model/update.go
+++ b/model/update.go
@@ -16,7 +16,9 @@ type UpdateOptions struct {
 	BaseURL           string // The BaseURL for the updates
 }
 
-// UpdateRequirements holds attributes that indicate requirements for before/after a component firmware install
+// UpdateRequirements are returned by utilities to help the caller identify actions (if any)
+// required before or after a firmware install.
 type UpdateRequirements struct {
-	PostInstallPowerCycle bool
+	PostInstallReconfiguration bool // The component requires a re-configuration post firmware install
+	PostInstallHostPowercycle  bool // The component requires a host power-cycle post firmware install
 }

--- a/providers/asrockrack/asrockrack.go
+++ b/providers/asrockrack/asrockrack.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/bmc-toolbox/common"
 	"github.com/metal-toolbox/ironlib/actions"
+	"github.com/metal-toolbox/ironlib/errs"
 	"github.com/metal-toolbox/ironlib/model"
 	"github.com/metal-toolbox/ironlib/utils"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -89,6 +91,12 @@ func (a *asrockrack) ListAvailableUpdates(context.Context, *model.UpdateOptions)
 // InstallUpdates for asrockrack based on updateOptions
 func (a *asrockrack) InstallUpdates(context.Context, *model.UpdateOptions) error {
 	return nil
+}
+
+// UpdateRequirements returns requirements to be met before and after a firmware install,
+// the caller may use the information to determine if a powercycle, reconfiguration or other actions are required on the component.
+func (a *asrockrack) UpdateRequirements(_ context.Context, _, _, _ string) (model.UpdateRequirements, error) {
+	return model.UpdateRequirements{}, errors.Wrap(errs.ErrUpdateReqNotImplemented, "provider: asrockrack")
 }
 
 // GetInventoryOEM collects device inventory using vendor specific tooling

--- a/providers/dell/dell.go
+++ b/providers/dell/dell.go
@@ -164,6 +164,12 @@ func (d *dell) ListAvailableUpdates(ctx context.Context, options *model.UpdateOp
 	return d.hw.Device, nil
 }
 
+// UpdateRequirements returns requirements to be met before and after a firmware install,
+// the caller may use the information to determine if a powercycle, reconfiguration or other actions are required on the component.
+func (d *dell) UpdateRequirements(_ context.Context, _, _, _ string) (model.UpdateRequirements, error) {
+	return model.UpdateRequirements{}, errors.Wrap(errs.ErrUpdateReqNotImplemented, "provider: generic")
+}
+
 // InstallUpdates for Dells based on updateOptions
 func (d *dell) InstallUpdates(ctx context.Context, options *model.UpdateOptions) error {
 	d.setUpdateOptions(options)

--- a/providers/generic/generic.go
+++ b/providers/generic/generic.go
@@ -84,6 +84,12 @@ func (a *Generic) ListAvailableUpdates(_ context.Context, _ *model.UpdateOptions
 	return nil, nil
 }
 
+// UpdateRequirements returns requirements to be met before and after a firmware install,
+// the caller may use the information to determine if a powercycle, reconfiguration or other actions are required on the component.
+func (a *Generic) UpdateRequirements(_ context.Context, _, _, _ string) (model.UpdateRequirements, error) {
+	return model.UpdateRequirements{}, errors.Wrap(errs.ErrUpdateReqNotImplemented, "provider: generic")
+}
+
 // InstallUpdates installs updates based on updateOptions
 func (a *Generic) InstallUpdates(_ context.Context, _ *model.UpdateOptions) error {
 	return nil

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrVersionStrExpectedSemver = errors.New("expected version string to follow semver format")
 	ErrFakeExecutorInvalidArgs  = errors.New("invalid number of args passed to fake executor")
 	ErrRepositoryBaseURL        = errors.New("repository base URL undefined, ensure UpdateOptions.BaseURL OR UPDATE_BASE_URL env var is set")
+	ErrRebootRequired           = errors.New("reboot required")
 )
 
 // ExecError is returned when the command exits with an error or a non zero exit status

--- a/utils/mlxup.go
+++ b/utils/mlxup.go
@@ -150,8 +150,8 @@ func setNICFirmware(d *MlxupDevice, firmware *common.Firmware) {
 }
 
 // UpdateRequirements implements the actions/NICUpdater interface to return any pre/post firmware install requirements.
-func (m *Mlxup) UpdateRequirements() model.UpdateRequirements {
-	return model.UpdateRequirements{PostInstallPowerCycle: true}
+func (m *Mlxup) UpdateRequirements(_ string) model.UpdateRequirements {
+	return model.UpdateRequirements{PostInstallHostPowercycle: true}
 }
 
 // UpdateNIC updates mellanox NIC with the given update file


### PR DESCRIPTION
### What does this PR do

- Adds `actions/UpdateComponent` to allow callers to target a specific component.
- Mellanox provider to return `ErrRebootRequired` when the nic indicates a reboot is necessary to proceed.
- Create a separate UpdateRequirementsGetter interface so utilities can opt to implement it.
- Update the `Getter` interface for `DeviceManager` to expose querying the update requirements.