### PR TITLE
Add sas protocol to discovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joelrebel @mmlb @splaspood @turegano-equinix @DoctorVin 
+* @joelrebel @mmlb @splaspood @turegano-equinix @doctorvin @ofaurax @jakeschuurmans @coffeefreak101

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joelrebel @mmlb @splaspood @turegano-equinix @doctorvin @ofaurax @jakeschuurmans @coffeefreak101
+* @turegano-equinix @metal-toolbox/provisioning-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,13 @@ RUN echo "Target ARCH is $TARGETARCH"
 
 # Bootstrap Dell DSU repository
 # Install Dell idracadm7 to enable collecting BIOS configuration and use install_weak_deps=0 to avoid pulling extra packages
+# The package srvadmin-idracadm7 is no longer available in the official repository due to end-of-life (EOL) of https://linux.dell.com/repo/hardware/dsu/.  
+# This is a workaround by pinning the DSU version to DSU_24.11.11, which still contains srvadmin-idracadm7.  
+# Related support case: https://www.dell.com/community/en/conversations/systems-management-general/racadm-missing-from-latest-linux-repo/67530fd3a9a6071a45ae51e6
+
 RUN if [[ $TARGETARCH == "amd64" ]]; then \
       curl -O https://linux.dell.com/repo/hardware/dsu/bootstrap.cgi && \
+      sed -i 's|REPO_URL="/repo/hardware/dsu/"|REPO_URL="/repo/hardware/DSU_24.11.11/"|' bootstrap.cgi && \
       bash bootstrap.cgi && \
       rm -f bootstrap.cgi && \
       microdnf install -y srvadmin-idracadm7; \

--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -450,7 +450,7 @@ func (a *InventoryCollectorAction) CollectDriveCapabilities(ctx context.Context)
 		//
 		// if theres others to be supported, the driveCapabilityCollectorByLogicalName() method
 		// is to be updated to include the required support for SAS/USB/SCSI or other kinds of transports.
-		if !slices.Contains([]string{"sata", "nvme"}, drive.Protocol) {
+		if !slices.Contains([]string{"sata", "nvme", "sas"}, drive.Protocol) {
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do
This PR adds `sas` drive protocol to the supported drive protocols (`sata`, `nvme`)

### The HW vendor this change applies to (if applicable)
This change is vendor-agnostic.

### The HW model number, product name this change applies to (if applicable)
Not specific to any particular hardware model. Applicable to any drives using `sas` protocol.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
Not dependent on any specific firmware or BIOS version.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

### How can this change be tested by a PR reviewer?
Test with drives using `sas` protocol.

### Description for changelog/release notes
Added: New supported drive protocol (`sas`).