### PR TITLE
github: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joelrebel @mmlb @splaspood @turegano-equinix @doctorvin @ofaurax @jakeschuurmans @coffeefreak101
+* @turegano-equinix @metal-toolbox/provisioning-core


### PR DESCRIPTION
### What does this PR do
Remove users who no longer are apart of the project, and add the provisioning-core group.

