### PR TITLE
Add sas protocol to discovery

### DIFF
--- a/actions/inventory.go
+++ b/actions/inventory.go
@@ -450,7 +450,7 @@ func (a *InventoryCollectorAction) CollectDriveCapabilities(ctx context.Context)
 		//
 		// if theres others to be supported, the driveCapabilityCollectorByLogicalName() method
 		// is to be updated to include the required support for SAS/USB/SCSI or other kinds of transports.
-		if !slices.Contains([]string{"sata", "nvme"}, drive.Protocol) {
+		if !slices.Contains([]string{"sata", "nvme", "sas"}, drive.Protocol) {
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do
This PR adds `sas` drive protocol to the supported drive protocols (`sata`, `nvme`)

### The HW vendor this change applies to (if applicable)
This change is vendor-agnostic.

### The HW model number, product name this change applies to (if applicable)
Not specific to any particular hardware model. Applicable to any drives using `sas` protocol.

### The BMC firmware and/or BIOS versions that this change applies to (if applicable)
Not dependent on any specific firmware or BIOS version.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

### How can this change be tested by a PR reviewer?
Test with drives using `sas` protocol.

### Description for changelog/release notes
Added: New supported drive protocol (`sas`).