### PR TITLE
lshw: build serial number for NICs if needed

### DIFF
--- a/utils/lshw.go
+++ b/utils/lshw.go
@@ -364,8 +364,9 @@ func (l *Lshw) xNIC(node *LshwNode) *common.NIC {
 
 	// TODO(splaspood) We should merge on something other than serial
 	if node.Serial == "" {
-		log.Printf("Warn: NIC component without serial, ignored: %+v\n", node)
-		return nil
+		vendor, product, _ := lshwPciIDParse(node.Product)
+		node.Serial = vendor + ":" + product + ":" + node.Businfo
+		log.Printf("Warn: NIC component without serial, using: %+v\n", node.Serial)
 	}
 
 	serial := strings.ToLower(node.Serial)


### PR DESCRIPTION
### What does this PR do

Build a serial number for NICs without one.

### Description for changelog/release notes

Reports NICs without serial number. Before, they were ignored.