### PR TITLE
Fix watermarks I/O blocking and ensure proper disk flush before watermarks verification

### DIFF
--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -68,8 +68,14 @@ func ApplyWatermarks(drive *common.Drive) (func() error, error) {
 	}
 	// We introduce a 500-millisecond delay to give the OS enough time to properly flush the disk buffers to disk.
 	// While this delay helps ensure that the data is written, it is not an ideal solution, and further investigation is needed to find more efficient synchronization mechanisms.
-	file.Sync()
-	file.Close()
+	err = file.Sync()
+	if err != nil {
+		return nil, fmt.Errorf("Error syncing: %v",err)
+	}
+	err = file.Close()
+	if err != nil {
+		return nil, fmt.Errorf("Error closing: %v",err)
+	}
 	time.Sleep(500 * time.Millisecond)
 	return checker, nil
 }

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -70,11 +70,11 @@ func ApplyWatermarks(drive *common.Drive) (func() error, error) {
 	// While this delay helps ensure that the data is written, it is not an ideal solution, and further investigation is needed to find more efficient synchronization mechanisms.
 	err = file.Sync()
 	if err != nil {
-		return nil, fmt.Errorf("Error syncing: %v", err)
+		return nil, err)
 	}
 	err = file.Close()
 	if err != nil {
-		return nil, fmt.Errorf("Error closing: %v", err)
+		return nil, err)
 	}
 	time.Sleep(500 * time.Millisecond)
 	return checker, nil

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"os"
 	"slices"
+	"time"
 
 	common "github.com/metal-toolbox/bmc-common"
 )

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -70,11 +70,11 @@ func ApplyWatermarks(drive *common.Drive) (func() error, error) {
 	// While this delay helps ensure that the data is written, it is not an ideal solution, and further investigation is needed to find more efficient synchronization mechanisms.
 	err = file.Sync()
 	if err != nil {
-		return nil, err)
+		return nil, err
 	}
 	err = file.Close()
 	if err != nil {
-		return nil, err)
+		return nil, err
 	}
 	time.Sleep(500 * time.Millisecond)
 	return checker, nil

--- a/utils/watermark_disk.go
+++ b/utils/watermark_disk.go
@@ -40,21 +40,21 @@ func ApplyWatermarks(drive *common.Drive) (func() error, error) {
 	checker := func() error {
 		// The delay gives the controller time to release I/O blocking, which could otherwise cause the verification process to fail due to incomplete or pending I/O operations.
 		time.Sleep(500 * time.Millisecond)
-		file, err := os.OpenFile(drive.LogicalName, os.O_RDONLY, 0)
+		checkFile, err := os.OpenFile(drive.LogicalName, os.O_RDONLY, 0)
 		if err != nil {
 			return err
 		}
-		defer file.Close()
+		defer checkFile.Close()
 
 		for i, watermark := range watermarks {
-			_, err = file.Seek(watermark.position, io.SeekStart)
+			_, err = checkFile.Seek(watermark.position, io.SeekStart)
 			if err != nil {
 				return fmt.Errorf("watermark verification, %s@%d(mark=%d), seek: %w", drive.LogicalName, watermark.position, i, err)
 			}
 
 			// Read the watermark written to the position
 			currentValue := make([]byte, watermarkSize)
-			_, err = io.ReadFull(file, currentValue)
+			_, err = io.ReadFull(checkFile, currentValue)
 			if err != nil {
 				return fmt.Errorf("read watermark %s@%d(mark=%d): %w", drive.LogicalName, watermark.position, i, err)
 			}


### PR DESCRIPTION
### What does this PR do
- Introduced a 500ms delay to allow the OS to flush disk buffers and prevent I/O blocking issues.
- Added `file.Sync()` to ensure data is written to disk before closing the file.
- Noted that the delay mitigates the issue but is not an ideal long-term solution, further investigation required for better synchronization mechanisms.

### How can this change be tested by a PR reviewer?
examples/diskwipe/main.go

### Description for changelog/release notes
Mitigated issues with watermarks synchronization during disk operations.
