### PR TITLE
When NICs are bonded, lshw reports wrong MAC (seen on Dell R6515)

### DIFF
--- a/.github/workflows/push-pr-lint.yaml
+++ b/.github/workflows/push-pr-lint.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
         args: --config .golangci.yml --timeout 2m
-        version: v1.61.0
+        version: v1.64.5
 
     - name: Check go generated files
       run: make check-go-generated

--- a/utils/lshw.go
+++ b/utils/lshw.go
@@ -136,6 +136,7 @@ func (l *Lshw) Collect(ctx context.Context, device *common.Device) error {
 		}
 
 		// collect components
+		// nolint:contextcheck // complains because xNIC uses a context
 		l.recurseNodes(parentNode.ChildNodes)
 	}
 

--- a/utils/smc_ipmicfg.go
+++ b/utils/smc_ipmicfg.go
@@ -14,6 +14,7 @@ import (
 
 const EnvSmcIpmicfgUtility = "IRONLIB_UTIL_SMC_IPMICFG"
 
+// nolint:recvcheck // TODO: pointer and non-pointer receivers
 type Ipmicfg struct {
 	Executor Executor
 }


### PR DESCRIPTION
### What does this PR do
Fix MAC address for bonded NICs because lshw reports MAC from the bond

### The HW model number, product name this change applies to (if applicable)
Tested on Dell R6515
