### PR TITLE
Added password removal to ata secure erase

### DIFF
--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -338,10 +338,14 @@ func (h *Hdparm) Erase(ctx context.Context, drive *common.Drive, ses SecureErase
 		return err
 	}
 
+	// This is a workaround to avoid the disk being locked after the erase.
 	h.Executor.SetArgs("--user-master", "u", "--security-disable", "p", drive.LogicalName)
 	_, err = h.Executor.Exec(ctx)
-	if err != nil {
-		return err
+	if err == nil {
+		// This is a weird one because this should error most of the time but
+		// we want to know when it doesn't error because that's a bug.
+		// So we log it but don't return an error.
+		logrus.WithField("drive", drive.LogicalName).Debug("hdparm --security-disable succeeded - this is unexpected")
 	}
 
 	return verify()

--- a/utils/hdparm.go
+++ b/utils/hdparm.go
@@ -338,6 +338,12 @@ func (h *Hdparm) Erase(ctx context.Context, drive *common.Drive, ses SecureErase
 		return err
 	}
 
+	h.Executor.SetArgs("--user-master", "u", "--security-disable", "p", drive.LogicalName)
+	_, err = h.Executor.Exec(ctx)
+	if err != nil {
+		return err
+	}
+
 	return verify()
 }
 


### PR DESCRIPTION
### What does this PR do
Adds a step to remove the set password during ATA Secure Erase

It is a bit weird because by default it should error (we already have the disk erased, so the password shouldn't be set.) But, we suspect that the drive is still locked in some cases (due to a bug somewhere on the disk) after the erase, so this will unlock it an send a log message.

### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
hdparm

### Description for changelog/release notes
- Fixed a bug in ATA Secure Erase where certain micron drives would still be password protected after an ATA secure erase