### PR TITLE
Pass UpdateFile as parameter, not slug

### DIFF
--- a/providers/dell/dell.go
+++ b/providers/dell/dell.go
@@ -179,7 +179,7 @@ func (d *dell) InstallUpdates(ctx context.Context, options *model.UpdateOptions)
 		return d.installAvailableUpdates(ctx, options.DownloadOnly)
 	}
 
-	exitCode, err := d.installUpdate(ctx, options.Slug, options.ForceInstall)
+	exitCode, err := d.installUpdate(ctx, options.UpdateFile, options.ForceInstall)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do

It correctly passes update file as parameter for dell udpates.
Previously, it was passing the slug, and then it failed on trying to `chmod nic` for a NIC update rather than `chmod`'ing the correct file.